### PR TITLE
Support display operator metrics

### DIFF
--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strings"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/osd-utils-cli/pkg/prom"
+	"github.com/spf13/cobra"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	operatorRoute          = awsAccountNamespace
+	operatorServiceAccount = awsAccountNamespace
+)
+
+// newCmdMetrics displays the metrics of aws-account-operator
+func newCmdMetrics(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newMetricsOptions(streams, flags)
+	resetCmd := &cobra.Command{
+		Use:                   "metrics [flags] [options]",
+		Short:                 "display metrics of aws-account-operator",
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	resetCmd.Flags().StringVar(&ops.accountNamespace, "account-namespace", awsAccountNamespace,
+		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
+	resetCmd.Flags().StringVarP(&ops.metricsURL, "metrics-url", "m", "", "The URL of aws-account-operator metrics endpoint. "+
+		"Used only for debug purpose! Only HTTP scheme is supported.")
+	resetCmd.Flags().StringVarP(&ops.routeName, "route", "r", operatorRoute, "The route created for aws-account-operator")
+	resetCmd.Flags().StringVar(&ops.saName, "sa", operatorServiceAccount, "The service account name for aws-account-operator")
+	resetCmd.Flags().BoolVar(&ops.useHTTPS, "https", false, "Use HTTPS to access metrics or not. By default we use HTTP scheme.")
+
+	return resetCmd
+}
+
+// metricsOptions defines the struct for running metrics command
+type metricsOptions struct {
+	accountNamespace string
+	routeName        string
+	saName           string
+	useHTTPS         bool
+
+	// the URL of aws-account-operator metrics endpoint
+	metricsURL string
+
+	flags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newMetricsOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *metricsOptions {
+	return &metricsOptions{
+		flags:     flags,
+		IOStreams: streams,
+	}
+}
+
+func (o *metricsOptions) complete(cmd *cobra.Command) error {
+	// account CR name and account ID cannot be empty at the same time
+	if o.metricsURL == "" && o.routeName == "" {
+		return cmdutil.UsageErrorf(cmd, "Metrics URL and route name cannot be empty at the same time")
+	}
+
+	var err error
+	configLoader := o.flags.ToRawKubeConfigLoader()
+	cfg, err := configLoader.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	cli, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	o.kubeCli = cli
+	return nil
+}
+
+func (o *metricsOptions) run() error {
+	var (
+		metricsEndpoint string
+		resp            *http.Response
+		err             error
+	)
+
+	ctx := context.TODO()
+
+	if o.metricsURL != "" {
+		metricsEndpoint = o.metricsURL
+		resp, err = http.Get(metricsEndpoint)
+	} else {
+		key := types.NamespacedName{
+			Namespace: o.accountNamespace,
+			Name:      o.routeName,
+		}
+
+		var route routev1.Route
+		if err := o.kubeCli.Get(ctx, key, &route); err != nil {
+			return err
+		}
+
+		if o.useHTTPS {
+			var sa v1.ServiceAccount
+			if err := o.kubeCli.Get(ctx, types.NamespacedName{
+				Namespace: o.accountNamespace,
+				Name:      o.saName,
+			}, &sa); err != nil {
+				return err
+			}
+
+			var secretName string
+			for _, v := range sa.Secrets {
+				if strings.Contains(v.Name, "token") {
+					secretName = v.Name
+				}
+			}
+			if secretName == "" {
+				return fmt.Errorf("secret for service account %s doesn't exist", o.saName)
+			}
+
+			var secret v1.Secret
+			if err := o.kubeCli.Get(ctx, types.NamespacedName{
+				Namespace: o.accountNamespace,
+				Name:      secretName,
+			}, &secret); err != nil {
+				return err
+			}
+
+			token, ok := secret.Data["token"]
+			if !ok {
+				return fmt.Errorf("secret %s doesn't have token field", secretName)
+			}
+			metricsEndpoint = "https://" + route.Spec.Host + "/metrics"
+			req, err := http.NewRequest(http.MethodGet, metricsEndpoint, nil)
+			if err != nil {
+				return err
+			}
+
+			req.Header.Add("Authorization", "Bearer "+string(token))
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			resp, err = http.DefaultClient.Do(req)
+		} else {
+			metricsEndpoint = "http://" + route.Spec.Host + "/metrics"
+			resp, err = http.Get(metricsEndpoint)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	metrics, err := prom.DecodeMetrics(resp.Body, map[string]string{"name": "aws-account-operator"})
+	if err != nil {
+		return err
+	}
+
+	for _, v := range metrics {
+		fmt.Fprintln(o.IOStreams.Out, v)
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	routev1 "github.com/openshift/api/route/v1"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/osd-utils-cli/cmd/list"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ import (
 
 func init() {
 	awsv1alpha1.AddToScheme(scheme.Scheme)
+	routev1.AddToScheme(scheme.Scheme)
 
 	NewCmdRoot(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 }
@@ -39,6 +41,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(newCmdSet(streams, kubeFlags))
 	rootCmd.AddCommand(list.NewCmdList(streams, kubeFlags))
 	rootCmd.AddCommand(newCmdConsole(streams, kubeFlags))
+	rootCmd.AddCommand(newCmdMetrics(streams, kubeFlags))
 
 	// add options command to list global flags
 	templates.ActsAsRootCommand(rootCmd, []string{"options"})

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.31.10
+	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/aws-account-operator v0.0.0-20200529133510-076b8c994393
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.10.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,9 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -88,7 +90,9 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/zapr v0.1.0 h1:h+WVe9j6HAA01niTJPA/kKH0i7e0rLZBCwauQFcRE54=
@@ -259,6 +263,8 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
+github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/aws-account-operator v0.0.0-20200529133510-076b8c994393 h1:SANfjUBDo4IxaQnWkx0UKnCwFV7LedoUmIs2zS/baf8=
 github.com/openshift/aws-account-operator v0.0.0-20200529133510-076b8c994393/go.mod h1:3JOgGxqzrQEGoJhGIIwrfHG6c0OjUhPuxVi0/KV14zQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -280,8 +286,9 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
+github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=

--- a/pkg/prom/prom.go
+++ b/pkg/prom/prom.go
@@ -1,0 +1,52 @@
+package prom
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+)
+
+// DecodeMetrics decodes Prometheus metrics.
+func DecodeMetrics(r io.Reader, matchers map[string]string) ([]string, error) {
+	dec := expfmt.NewDecoder(r, expfmt.FmtText)
+	decoder := expfmt.SampleDecoder{
+		Dec:  dec,
+		Opts: &expfmt.DecodeOptions{},
+	}
+
+	res := make([]string, 0)
+	for {
+		var vector model.Vector
+		if err := decoder.Decode(&vector); err != nil {
+			if err == io.EOF {
+				break
+			}
+			continue
+		}
+		for _, metric := range vector {
+			if matchLabels(metric.Metric, matchers) {
+				res = append(res, fmt.Sprintf("%s => %f", metric.Metric, metric.Value))
+			}
+		}
+	}
+
+	sort.Strings(res)
+
+	return res, nil
+}
+
+// matchLabels checks whether the metric has the required labels or not
+func matchLabels(metric model.Metric, matchers map[string]string) bool {
+	for k, v := range matchers {
+		if labelValue, ok := metric[model.LabelName(k)]; !ok {
+			return false
+		} else if string(labelValue) != v {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fixes https://issues.redhat.com/browse/OSD-3954

Usage

```
osd-utils-cli metrics -h
display metrics of aws-account-operator

Options:
      --account-namespace='aws-account-operator': The namespace to keep AWS accounts. The default value is
aws-account-operator.
      --route='aws-account-operator': The route created for aws-account-operator
      --sa='aws-account-operator': The service account name for aws-account-operator

Usage:
  osd-utils-cli metrics [flags] [options]

Use "osd-utils-cli options" for a list of global command-line options (applies to all commands).
```