### PR TITLE
support aws account credentials secret validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,15 @@ osdctl clean-velero-snapshots -a <AWS ACCESS KEY ID> -x <AWS SECRET ACCESS KEY>
 # we also support specifying profile and config file path
 osdctl clean-velero-snapshots -p <profile name> -c <config file path>
 ```
+
+### AWS Account IAM User Credentials validation
+
+`check-secrets` command checks the IAM User Secret associated with Account Accout CR.
+
+```bash
+# no argument, check all account secrets
+osdctl check-secrets
+
+# specify the Account CR name, then only check the IAM User Secret for that Account.
+osdctl check-secrets <Account CR Name>
+```

--- a/cmd/check-secrets.go
+++ b/cmd/check-secrets.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/spf13/cobra"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/osd-utils-cli/pkg/k8s"
+	awsprovider "github.com/openshift/osd-utils-cli/pkg/provider/aws"
+)
+
+const (
+	checkSecretsUsage = "The check-secrets command should have only 0 or 1 arguments"
+)
+
+// newCmdCheckSecrets implements the check-secrets command
+// which checks AWS credentials managed by AWS Account Operator
+func newCmdCheckSecrets(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newCheckSecretsOptions(streams, flags)
+	checkSecretsCmd := &cobra.Command{
+		Use:               "check-secrets [<account name>]",
+		Short:             "check AWS Account CR IAM User credentials",
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	checkSecretsCmd.Flags().StringVar(&ops.accountNamespace, "account-namespace", awsAccountNamespace,
+		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
+	checkSecretsCmd.Flags().BoolVarP(&ops.verbose, "verbose", "v", false, "Verbose output")
+
+	return checkSecretsCmd
+}
+
+// checkSecretsOptions defines the struct for running check command
+type checkSecretsOptions struct {
+	accountName      string
+	accountNamespace string
+
+	verbose bool
+
+	flags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newCheckSecretsOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *checkSecretsOptions {
+	return &checkSecretsOptions{
+		flags:     flags,
+		IOStreams: streams,
+	}
+}
+
+func (o *checkSecretsOptions) complete(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return cmdutil.UsageErrorf(cmd, checkSecretsUsage)
+	}
+
+	if len(args) == 1 {
+		o.accountName = args[0]
+	}
+
+	var err error
+	o.kubeCli, err = k8s.NewClient(o.flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *checkSecretsOptions) run() error {
+	ctx := context.TODO()
+	var (
+		awsClient   awsprovider.Client
+		credentials []*awsSecret
+		err         error
+	)
+	if o.accountName == "" {
+		var accounts awsv1alpha1.AccountList
+		if err := o.kubeCli.List(ctx, &accounts, &client.ListOptions{
+			Namespace: o.accountNamespace,
+		}); err != nil {
+			return err
+		}
+
+		for _, account := range accounts.Items {
+			if account.Spec.IAMUserSecret == "" {
+				continue
+			}
+			if o.verbose {
+				fmt.Fprintln(o.IOStreams.Out, "Getting AWS Credentials for account "+account.Name)
+			}
+			creds, err := k8s.GetAWSAccountCredentials(ctx, o.kubeCli, o.accountNamespace, account.Spec.IAMUserSecret)
+			if err != nil {
+				if apierrors.IsNotFound(err) && account.Status.State != "Creating" {
+					fmt.Fprintf(o.IOStreams.Out, "Account %s doesn't have associate credentials, state %s",
+						account.Name, account.Status.State)
+				}
+				continue
+			}
+			credentials = append(credentials, &awsSecret{
+				secret: account.Spec.IAMUserSecret,
+				awsCreds: &awsprovider.AwsClientInput{
+					AwsIDKey:     creds.AwsIDKey,
+					AwsAccessKey: creds.AwsAccessKey,
+				},
+			})
+		}
+	} else {
+		account, err := k8s.GetAWSAccount(ctx, o.kubeCli, o.accountNamespace, o.accountName)
+		if err != nil {
+			return err
+		}
+		if account.Spec.IAMUserSecret == "" {
+			return fmt.Errorf("account %s doesn't have associate credentials", account.Name)
+		}
+		if o.verbose {
+			fmt.Fprintln(o.IOStreams.Out, "Getting AWS Credentials for account "+account.Name)
+		}
+		creds, err := k8s.GetAWSAccountCredentials(ctx, o.kubeCli, o.accountNamespace, account.Spec.IAMUserSecret)
+		if err != nil {
+			return err
+		}
+		credentials = append(credentials, &awsSecret{
+			secret: account.Spec.IAMUserSecret,
+			awsCreds: &awsprovider.AwsClientInput{
+				AwsIDKey:     creds.AwsIDKey,
+				AwsAccessKey: creds.AwsAccessKey,
+			},
+		})
+	}
+
+	for _, cred := range credentials {
+		if o.verbose {
+			fmt.Fprintln(o.IOStreams.Out, "Start validating secret "+cred.secret)
+		}
+		awsClient, err = awsprovider.NewAwsClientWithInput(cred.awsCreds)
+		if err != nil {
+			fmt.Fprintf(o.IOStreams.Out, "Failed to create AWS client with secret %s\n", cred.secret)
+			continue
+		}
+		if _, err := awsClient.GetCallerIdentity(
+			&sts.GetCallerIdentityInput{}); err != nil {
+			fmt.Fprintf(o.IOStreams.Out, "Failed to get caller identity with secret %s\n", cred.secret)
+			continue
+		}
+	}
+
+	return nil
+}
+
+type awsSecret struct {
+	awsCreds *awsprovider.AwsClientInput
+	secret   string
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(newCmdConsole(streams, kubeFlags))
 	rootCmd.AddCommand(newCmdMetrics(streams, kubeFlags))
 	rootCmd.AddCommand(newCmdCleanVeleroSnapshots(streams))
+	rootCmd.AddCommand(newCmdCheckSecrets(streams, kubeFlags))
 
 	// add docs command
 	rootCmd.AddCommand(newCmdDocs(streams))

--- a/docs/command/osdctl.md
+++ b/docs/command/osdctl.md
@@ -13,30 +13,19 @@ osdctl [flags]
 ### Options
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-  -h, --help                             help for osdctl
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+  -h, --help                       help for osdctl
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO
 
+* [osdctl check-secrets](osdctl_check-secrets.md)	 - check AWS Account CR IAM User credentials
 * [osdctl clean-velero-snapshots](osdctl_clean-velero-snapshots.md)	 - cleans up S3 buckets whose name start with managed-velero
 * [osdctl console](osdctl_console.md)	 - generate an AWS console URL on the fly
 * [osdctl list](osdctl_list.md)	 - list resources

--- a/docs/command/osdctl_check-secrets.md
+++ b/docs/command/osdctl_check-secrets.md
@@ -1,19 +1,21 @@
-## osdctl options
+## osdctl check-secrets
 
-Print the list of flags inherited by all commands
+check AWS Account CR IAM User credentials
 
 ### Synopsis
 
-Print the list of flags inherited by all commands
+check AWS Account CR IAM User credentials
 
 ```
-osdctl options
+osdctl check-secrets [<account name>] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+      --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -h, --help                       help for check-secrets
+  -v, --verbose                    Verbose output
 ```
 
 ### Options inherited from parent commands

--- a/docs/command/osdctl_clean-velero-snapshots.md
+++ b/docs/command/osdctl_clean-velero-snapshots.md
@@ -24,25 +24,13 @@ osdctl clean-velero-snapshots <account name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO

--- a/docs/command/osdctl_console.md
+++ b/docs/command/osdctl_console.md
@@ -26,25 +26,13 @@ osdctl console [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO

--- a/docs/command/osdctl_list.md
+++ b/docs/command/osdctl_list.md
@@ -19,25 +19,13 @@ osdctl list [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO

--- a/docs/command/osdctl_list_account.md
+++ b/docs/command/osdctl_list_account.md
@@ -22,25 +22,13 @@ osdctl list account [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO

--- a/docs/command/osdctl_metrics.md
+++ b/docs/command/osdctl_metrics.md
@@ -24,25 +24,13 @@ osdctl metrics [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO

--- a/docs/command/osdctl_reset.md
+++ b/docs/command/osdctl_reset.md
@@ -20,25 +20,13 @@ osdctl reset <account name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO

--- a/docs/command/osdctl_set.md
+++ b/docs/command/osdctl_set.md
@@ -24,25 +24,13 @@ osdctl set <account name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --add_dir_header                   If true, adds the file directory to the header
-      --alsologtostderr                  log to standard error as well as files
-      --cluster string                   The name of the kubeconfig cluster to use
-      --context string                   The name of the kubeconfig context to use
-      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                   If non-empty, write log files in this directory
-      --log_file string                  If non-empty, use this log file
-      --log_file_max_size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                      log to standard error instead of files (default true)
-  -n, --namespace string                 If present, the namespace scope for this CLI request
-      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -s, --server string                    The address and port of the Kubernetes API server
-      --skip_headers                     If true, avoid header prefixes in the log messages
-      --skip_log_headers                 If true, avoid headers when opening log files
-      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-  -v, --v Level                          number for the log level verbosity
-      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string           If present, the namespace scope for this CLI request
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	k8s.io/apimachinery v0.18.3
 	k8s.io/cli-runtime v0.18.3
 	k8s.io/client-go v0.18.3
-	k8s.io/component-base v0.18.3
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.18.3
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/component-base/logs"
 )
 
 func main() {
@@ -17,9 +16,6 @@ func main() {
 	flags := pflag.NewFlagSet("osdctl", pflag.ExitOnError)
 	flag.CommandLine.Parse([]string{})
 	pflag.CommandLine = flags
-
-	logs.InitLogs()
-	defer logs.FlushLogs()
 
 	command := cmd.NewCmdRoot(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fixes https://issues.redhat.com/browse/OSD-4016

This command has two usage.

1. don't have any arguments, then it will check all account secrets

```
osd-utils-cli check-secrets
```

2. have one argument `account name`, then it will validate the credentials associated with this account cr.

```
osd-utils-cli check-secrets <account cr name>
```