### PR TITLE
Fix go vet error

### DIFF
--- a/pkg/provider/aws/iam.go
+++ b/pkg/provider/aws/iam.go
@@ -119,7 +119,7 @@ func getSignInToken(creds *sts.Credentials) (string, error) {
 
 	data, err := json.Marshal(jsonCreds)
 	if err != nil {
-		klog.Error("Failed to marshal federation credentials %v", err)
+		klog.Errorf("Failed to marshal federation credentials %v", err)
 		return "", err
 	}
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

``` bash
go vet ./...
# github.com/openshift/osd-utils-cli/pkg/provider/aws
pkg/provider/aws/iam.go:122:3: Error call has possible formatting directive %v
make: *** [Makefile:20: vet] Error 2
```
