### PR TITLE
Customize kubernetes flags to avoid CI failure

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/pointer"
 )
 
 func init() {
@@ -33,8 +34,17 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
-	// Reuse kubectl global flags to provide namespace, context and credential options
-	kubeFlags := genericclioptions.NewConfigFlags(false)
+	// Reuse kubectl global flags to provide namespace, context and credential options.
+	// We are not using NewConfigFlags here to avoid adding too many flags
+	kubeFlags := &genericclioptions.ConfigFlags{
+		KubeConfig:  pointer.StringPtr(""),
+		ClusterName: pointer.StringPtr(""),
+		Context:     pointer.StringPtr(""),
+		Namespace:   pointer.StringPtr(""),
+		APIServer:   pointer.StringPtr(""),
+		Timeout:     pointer.StringPtr("0"),
+		Insecure:    pointer.BoolPtr(false),
+	}
 	kubeFlags.AddFlags(rootCmd.PersistentFlags())
 
 	// add sub commands

--- a/docs/command/osd-utils-cli.md
+++ b/docs/command/osd-utils-cli.md
@@ -15,12 +15,6 @@ osd-utils-cli [flags]
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for osd-utils-cli
@@ -37,9 +31,6 @@ osd-utils-cli [flags]
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/command/osd-utils-cli_console.md
+++ b/docs/command/osd-utils-cli_console.md
@@ -26,12 +26,6 @@ osd-utils-cli console [flags]
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -47,9 +41,6 @@ osd-utils-cli console [flags]
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/command/osd-utils-cli_list.md
+++ b/docs/command/osd-utils-cli_list.md
@@ -21,12 +21,6 @@ osd-utils-cli list [flags]
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -42,9 +36,6 @@ osd-utils-cli list [flags]
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/command/osd-utils-cli_list_account.md
+++ b/docs/command/osd-utils-cli_list_account.md
@@ -24,12 +24,6 @@ osd-utils-cli list account [flags]
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -45,9 +39,6 @@ osd-utils-cli list account [flags]
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/command/osd-utils-cli_metrics.md
+++ b/docs/command/osd-utils-cli_metrics.md
@@ -26,12 +26,6 @@ osd-utils-cli metrics [flags]
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -47,9 +41,6 @@ osd-utils-cli metrics [flags]
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/command/osd-utils-cli_options.md
+++ b/docs/command/osd-utils-cli_options.md
@@ -21,12 +21,6 @@ osd-utils-cli options
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -42,9 +36,6 @@ osd-utils-cli options
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/command/osd-utils-cli_reset.md
+++ b/docs/command/osd-utils-cli_reset.md
@@ -22,12 +22,6 @@ osd-utils-cli reset <account name> [flags]
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -43,9 +37,6 @@ osd-utils-cli reset <account name> [flags]
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/docs/command/osd-utils-cli_set.md
+++ b/docs/command/osd-utils-cli_set.md
@@ -26,12 +26,6 @@ osd-utils-cli set <account name> [flags]
 ```
       --add_dir_header                   If true, adds the file directory to the header
       --alsologtostderr                  log to standard error as well as files
-      --as string                        Username to impersonate for the operation
-      --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
-      --certificate-authority string     Path to a cert file for the certificate authority
-      --client-certificate string        Path to a client certificate file for TLS
-      --client-key string                Path to a client key file for TLS
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -47,9 +41,6 @@ osd-utils-cli set <account name> [flags]
       --skip_headers                     If true, avoid header prefixes in the log messages
       --skip_log_headers                 If true, avoid headers when opening log files
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
-      --tls-server-name string           Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-      --token string                     Bearer token for authentication to the API server
-      --user string                      The name of the kubeconfig user to use
   -v, --v Level                          number for the log level verbosity
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
 ```

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,6 @@ require (
 	k8s.io/component-base v0.18.3
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.18.3
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 	sigs.k8s.io/controller-runtime v0.6.0
 )


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

The prow CI fails because of the error.

```
error: some steps failed:
  * could not run steps: step lint failed: test "lint" failed: the pod ci-op-wr202wq3/lint failed after 47s (failed containers: test): ContainerFailed one or more containers exited
Container test exited with code 2, reason Error
---
/osd-utils-cli_reset.md b/docs/command/osd-utils-cli_reset.md
index 30d541c..3e64514 100644
--- a/docs/command/osd-utils-cli_reset.md
+++ b/docs/command/osd-utils-cli_reset.md
@@ -24,7 +24,7 @@ osd-utils-cli reset <account name> [flags]
       --alsologtostderr                  log to standard error as well as files
       --as string                        Username to impersonate for the operation
       --as-group stringArray             Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string                 Default HTTP cache directory (default "/home/yeya24/.kube/http-cache")
+      --cache-dir string                 Default HTTP cache directory (default "/.kube/http-cache")
       --certificate-authority string     Path to a cert file for the certificate authority
       --client-certificate string        Path to a client certificate file for TLS
       --client-key string                Path to a client key file for TLS
diff --git a/docs/command/osd-utils-cli_set.md b/docs/command/osd-utils-cli_set.md
index 379aac7..7d3d51f 100644
```

The flag `cache-dir` uses an environment-specific value as default, causing inconsistency between CI and local. So this pr just cleans up some not very important Kubernetes flags to make CI work.

```
defaultCacheDir = filepath.Join(homedir.HomeDir(), ".kube", "http-cache")
```