### PR TITLE
Add a prompt in the reset command before actually resetting account

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,18 @@ For the detailed usage of each command, please refer to [here](./docs/command).
 
 ``` bash
 osdctl reset test-cr
+Reset account test-cr? (Y/N) y
 
 Deleting secret test-cr-osdmanagedadminsre-secret
 Deleting secret test-cr-secret
 Deleting secret test-cr-sre-cli-credentials
 Deleting secret test-cr-sre-console-url
+```
+
+You can skip the prompt by adding a flag `-y`, but it is not recommended.
+
+```bash
+osdctl reset test-cr -y
 ```
 
 ### AWS Account CR status patch


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Now the `reset` command has a prompt to let users to verify if they really want to reset the account.

``` bash
osd-utils-cli reset test-cr
Reset account test-cr? (Y/N)