### PR TITLE
Add two flags to specify AWS profile and AWS config file

### DIFF
--- a/cmd/console.go
+++ b/cmd/console.go
@@ -39,6 +39,8 @@ func newCmdConsole(streams genericclioptions.IOStreams, flags *genericclioptions
 		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
 	consoleCmd.Flags().StringVarP(&ops.accountName, "account-name", "a", "", "The AWS account cr we need to create AWS console URL for")
 	consoleCmd.Flags().StringVarP(&ops.accountID, "account-id", "i", "", "The AWS account ID we need to create AWS console URL for")
+	consoleCmd.Flags().StringVarP(&ops.profile, "aws-profile", "p", "", "specify AWS profile")
+	consoleCmd.Flags().StringVarP(&ops.cfgFile, "aws-config", "c", "", "specify AWS config file")
 	consoleCmd.Flags().StringVarP(&ops.region, "aws-region", "r", defaultRegion, "specify AWS region")
 	consoleCmd.Flags().Int64VarP(&ops.consoleDuration, "duration", "d", 3600, "The duration of the console session. "+
 		"Default value is 3600 seconds(1 hour)")
@@ -54,7 +56,9 @@ type consoleOptions struct {
 	consoleDuration  int64
 
 	// AWS config
-	region string
+	region  string
+	profile string
+	cfgFile string
 
 	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
@@ -92,7 +96,7 @@ func (o *consoleOptions) complete(cmd *cobra.Command) error {
 
 func (o *consoleOptions) run() error {
 	var err error
-	awsClient, err := awsprovider.NewAwsClient(o.region)
+	awsClient, err := awsprovider.NewAwsClient(o.profile, o.region, o.cfgFile)
 	if err != nil {
 		return err
 	}

--- a/docs/command/osd-utils-cli_console.md
+++ b/docs/command/osd-utils-cli_console.md
@@ -16,6 +16,8 @@ osd-utils-cli console [flags]
   -i, --account-id string          The AWS account ID we need to create AWS console URL for
   -a, --account-name string        The AWS account cr we need to create AWS console URL for
       --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -c, --aws-config string          specify AWS config file
+  -p, --aws-profile string         specify AWS profile
   -r, --aws-region string          specify AWS region (default "us-east-1")
   -d, --duration int               The duration of the console session. Default value is 3600 seconds(1 hour) (default 3600)
   -h, --help                       help for console


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fixes https://issues.redhat.com/browse/OSD-4101

Now you can use the flags `-p` to specify profile and use `-c` to specify config file