### PR TITLE
Add build flags to test target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ docs: build
 	@git diff --exit-code -- ./docs/command/
 
 test:
-	$(GO) test ./... -cover $(PACKAGES)
+	$(GO) test ${BUILDFLAGS} ./... -cover $(PACKAGES)


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

CI is failing because I forgot to add `${BUILDFLAGS}` :(

