### PR TITLE
Support output format for osdctl account list

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ osdctl account list --state=Creating
 
 Name                State               AWS ACCOUNT ID      Last Probe Time                 Last Transition Time            Message
 test-cr             Creating            181787396432        2020-06-18 10:38:40 -0400 EDT   2020-06-18 10:38:40 -0400 EDT   AWS account already created
+
+# filter accounts by reused or claimed status
+osdctl account list --reuse=true --claim=false
+
+# custom output using jsonpath
+osdctl account list -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.awsAccountID}{"\t"}{.status.state}{"\n"}{end}'
 ```
 
 ### AWS Account Console URL generate

--- a/docs/command/osdctl_account_list.md
+++ b/docs/command/osdctl_account_list.md
@@ -14,9 +14,12 @@ osdctl account list [flags]
 
 ```
       --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -c, --claim string               Filter account CRs by claimed or not. Supported values are true, false. Otherwise it lists all accounts
   -h, --help                       help for list
-  -r, --reuse                      Only list reused accounts CR if true
-      --state string               Account cr state. If not specified, it will list all crs by default.
+  -o, --output string              Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].
+  -r, --reuse string               Filter account CRs by reused or not. Supported values are true, false. Otherwise it lists all accounts
+      --state string               Account cr state. The default value is all to display all the crs (default "all")
+      --template string            Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.
 ```
 
 ### Options inherited from parent commands

--- a/pkg/printer/print_flags.go
+++ b/pkg/printer/print_flags.go
@@ -1,0 +1,45 @@
+package printer
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+)
+
+type PrintFlags struct {
+	JSONYamlFlags *genericclioptions.JSONYamlPrintFlags
+	JSONPathFlags *genericclioptions.JSONPathPrintFlags
+}
+
+func NewPrintFlags() *PrintFlags {
+	template := ""
+	return &PrintFlags{
+		JSONYamlFlags: genericclioptions.NewJSONYamlPrintFlags(),
+		JSONPathFlags: &genericclioptions.JSONPathPrintFlags{TemplateArgument: &template},
+	}
+}
+
+func (p *PrintFlags) AddFlags(c *cobra.Command) {
+	p.JSONYamlFlags.AddFlags(c)
+	p.JSONPathFlags.AddFlags(c)
+}
+
+func (p *PrintFlags) ToPrinter(output string) (printers.ResourcePrinter, error) {
+	if p, err := p.JSONYamlFlags.ToPrinter(output); !genericclioptions.IsNoCompatiblePrinterError(err) {
+		return p, err
+	}
+
+	if p, err := p.JSONPathFlags.ToPrinter(output); !genericclioptions.IsNoCompatiblePrinterError(err) {
+		return p, err
+	}
+
+	return nil, genericclioptions.NoCompatiblePrinterError{OutputFormat: &output, AllowedFormats: p.AllowedFormats()}
+}
+
+// AllowedFormats is the list of formats in which data can be displayed
+func (p *PrintFlags) AllowedFormats() []string {
+	formats := p.JSONYamlFlags.AllowedFormats()
+	formats = append(formats, p.JSONPathFlags.AllowedFormats()...)
+	return formats
+}

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -3,12 +3,14 @@ package printer
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io"
-	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"gopkg.in/yaml.v2"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // printer use to output something on screen with table format.


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

Fixes https://issues.redhat.com/browse/OSD-4313

Now we can specify -o in `osdctl account list` command.

If you want to customize the output, you can use -o jsonpath like the example below.

```
osdctl account list -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.awsAccountID}{"\t"}{.status.state}{"\n"}{end}'
```