### PR TITLE
Refactor osdctl account get output

### DIFF
--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -1,9 +1,10 @@
 package account
 
 import (
-	"github.com/openshift/osd-utils-cli/cmd/account/get"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/osd-utils-cli/cmd/account/get"
 )
 
 // NewCmdAccount implements the base account command

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -2,14 +2,14 @@ package account
 
 import (
 	"context"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/printers"
 	"time"
 
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/spf13/cobra"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 

--- a/docs/command/osdctl_account_get_account-claim.md
+++ b/docs/command/osdctl_account_get_account-claim.md
@@ -16,7 +16,8 @@ osdctl account get account-claim [flags]
   -i, --account-id string          AWS account ID
       --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
   -h, --help                       help for account-claim
-  -o, --output string              Output format, json and yaml are supported.
+  -o, --output string              Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].
+      --template string            Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.
 ```
 
 ### Options inherited from parent commands

--- a/docs/command/osdctl_account_get_account.md
+++ b/docs/command/osdctl_account_get_account.md
@@ -18,7 +18,8 @@ osdctl account get account [flags]
   -i, --account-id string          AWS account ID
       --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
   -h, --help                       help for account
-  -o, --output string              Output format, json and yaml are supported.
+  -o, --output string              Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].
+      --template string            Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/prometheus/common v0.10.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
-	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.3
 	k8s.io/apimachinery v0.18.3
 	k8s.io/cli-runtime v0.18.3

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -1,16 +1,11 @@
 package printer
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
-
-	"gopkg.in/yaml.v2"
-
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // printer use to output something on screen with table format.
@@ -38,26 +33,4 @@ func (p *printer) Flush() error {
 func (p *printer) ClearScreen() {
 	fmt.Fprint(os.Stdout, "\033[2J")
 	fmt.Fprint(os.Stdout, "\033[H")
-}
-
-func FormatOutput(w io.Writer, format string, obj runtime.Object) error {
-	var (
-		bytes []byte
-		err   error
-	)
-	switch format {
-	case "yaml":
-		bytes, err = yaml.Marshal(obj)
-	case "json":
-		bytes, err = json.Marshal(obj)
-	default:
-		return fmt.Errorf("Unsupported format %s\n", format)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(w, string(bytes))
-	return nil
 }


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

Adopt the kubectl way to output Kubernetes resource. I think it is much more cleaner than before.

Also supports `jsonpath` and `jsonpath-file` output format.

Fixes https://github.com/openshift/osd-utils-cli/issues/44