### PR TITLE
Adds account cli credential generation

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -1,0 +1,135 @@
+package account
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/osd-utils-cli/cmd/common"
+	"github.com/openshift/osd-utils-cli/pkg/k8s"
+	awsprovider "github.com/openshift/osd-utils-cli/pkg/provider/aws"
+)
+
+// newCmdCli implements the Cli command which generates temporary STS cli credentials for the specified account cr
+func newCmdCli(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newCliOptions(streams, flags)
+	cliCmd := &cobra.Command{
+		Use:               "cli",
+		Short:             "Generate temporary AWS CLI credentials on demand",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	cliCmd.Flags().StringVar(&ops.accountNamespace, "account-namespace", common.AWSAccountNamespace,
+		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
+	cliCmd.Flags().StringVarP(&ops.accountName, "account-name", "a", "", "The AWS Account CR name to generate the credentials for")
+	cliCmd.Flags().StringVarP(&ops.accountID, "account-id", "i", "", "The AWS Account ID we need to create temporary AWS credentials for")
+	cliCmd.Flags().StringVarP(&ops.profile, "aws-profile", "p", "", "specify AWS profile")
+	cliCmd.Flags().StringVarP(&ops.cfgFile, "aws-config", "c", "", "specify AWS config file path")
+	cliCmd.Flags().StringVarP(&ops.region, "aws-region", "r", common.DefaultRegion, "specify AWS region")
+	cliCmd.Flags().Int64VarP(&ops.cliDuration, "duration", "d", 3600, "The duration of the cli token. "+
+		"Default value is 3600 seconds(1 hour)")
+	cliCmd.Flags().BoolVarP(&ops.verbose, "verbose", "v", false, "Verbose output")
+
+	return cliCmd
+}
+
+// cliOptions defines the struct for running the cli command
+type cliOptions struct {
+	accountName      string
+	accountID        string
+	accountNamespace string
+	cliDuration      int64
+
+	// AWS config
+	region  string
+	profile string
+	cfgFile string
+
+	verbose bool
+
+	flags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newCliOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cliOptions {
+	return &cliOptions{
+		flags:     flags,
+		IOStreams: streams,
+	}
+}
+
+func (o *cliOptions) complete(cmd *cobra.Command) error {
+	// account CR name and account ID cannot be empty at the same time
+	if o.accountName == "" && o.accountID == "" {
+		return cmdutil.UsageErrorf(cmd, "AWS account CR name and AWS account ID cannot be empty at the same time")
+	}
+
+	if o.accountName != "" && o.accountID != "" {
+		return cmdutil.UsageErrorf(cmd, "AWS account CR name and AWS account ID cannot be set at the same time")
+	}
+
+	// only initialize kubernetes client when account name is set
+	if o.accountName != "" {
+		var err error
+		o.kubeCli, err = k8s.NewClient(o.flags)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *cliOptions) run() error {
+	var err error
+	awsClient, err := awsprovider.NewAwsClient(o.profile, o.region, o.cfgFile)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.TODO()
+	var accountID string
+	if o.accountName != "" {
+		account, err := k8s.GetAWSAccount(ctx, o.kubeCli, o.accountNamespace, o.accountName)
+		if err != nil {
+			return err
+		}
+		accountID = account.Spec.AwsAccountID
+	} else {
+		accountID = o.accountID
+	}
+
+	callerIdentityOutput, err := awsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		klog.Error("Fail to get caller identity. Could you please validate the credentials?")
+		return err
+	}
+	if o.verbose {
+		fmt.Println(callerIdentityOutput)
+	}
+
+	roleName := awsv1alpha1.AccountOperatorIAMRole
+	credentials, err := awsprovider.GetAssumeRoleCredentials(awsClient, &o.cliDuration,
+		callerIdentityOutput.UserId, aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName)))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(o.IOStreams.Out, "Temporary AWS Credentials:\n%s\n", credentials)
+
+	return nil
+}

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -19,6 +19,7 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 	accountCmd.AddCommand(newCmdReset(streams, flags))
 	accountCmd.AddCommand(newCmdSet(streams, flags))
 	accountCmd.AddCommand(newCmdConsole(streams, flags))
+	accountCmd.AddCommand(newCmdCli(streams, flags))
 	accountCmd.AddCommand(newCmdList(streams, flags))
 	accountCmd.AddCommand(newCmdCleanVeleroSnapshots(streams))
 	accountCmd.AddCommand(newCmdCheckSecrets(streams, flags))

--- a/docs/command/osdctl_account.md
+++ b/docs/command/osdctl_account.md
@@ -32,6 +32,7 @@ osdctl account [flags]
 * [osdctl](osdctl.md)	 - OSD CLI
 * [osdctl account check-secrets](osdctl_account_check-secrets.md)	 - Check AWS Account CR IAM User credentials
 * [osdctl account clean-velero-snapshots](osdctl_account_clean-velero-snapshots.md)	 - Cleans up S3 buckets whose name start with managed-velero
+* [osdctl account cli](osdctl_account_cli.md)	 - Generate temporary AWS CLI credentials on demand
 * [osdctl account console](osdctl_account_console.md)	 - Generate an AWS console URL on the fly
 * [osdctl account get](osdctl_account_get.md)	 - get resources
 * [osdctl account list](osdctl_account_list.md)	 - List AWS Account CR

--- a/docs/command/osdctl_account_cli.md
+++ b/docs/command/osdctl_account_cli.md
@@ -1,0 +1,41 @@
+## osdctl account cli
+
+Generate temporary AWS CLI credentials on demand
+
+### Synopsis
+
+Generate temporary AWS CLI credentials on demand
+
+```
+osdctl account cli [flags]
+```
+
+### Options
+
+```
+  -i, --account-id string          The AWS Account ID we need to create temporary AWS credentials for
+  -a, --account-name string        The AWS Account CR name to generate the credentials for
+      --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -c, --aws-config string          specify AWS config file path
+  -p, --aws-profile string         specify AWS profile
+  -r, --aws-region string          specify AWS region (default "us-east-1")
+  -d, --duration int               The duration of the cli token. Default value is 3600 seconds(1 hour) (default 3600)
+  -h, --help                       help for cli
+  -v, --verbose                    Verbose output
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
+```
+
+### SEE ALSO
+
+* [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+

--- a/pkg/provider/aws/sts.go
+++ b/pkg/provider/aws/sts.go
@@ -38,7 +38,7 @@ type sessionPayload struct {
 // RequestSignInToken makes a HTTP request to retrieve an AWS SignIn Token
 // via the AWS Federation endpoint
 func RequestSignInToken(awsClient Client, durationSeconds *int64, sessionName, roleArn *string) (string, error) {
-	credentials, err := getAssumeRoleCredentials(awsClient, durationSeconds, sessionName, roleArn)
+	credentials, err := GetAssumeRoleCredentials(awsClient, durationSeconds, sessionName, roleArn)
 	if err != nil {
 		return "", err
 	}
@@ -61,8 +61,8 @@ func RequestSignInToken(awsClient Client, durationSeconds *int64, sessionName, r
 	return signedFederationURL.String(), nil
 }
 
-// getAssumeRoleCredentials gets the Federation Token from AWS.
-func getAssumeRoleCredentials(awsClient Client, durationSeconds *int64, roleSessionName, roleArn *string) (*sts.Credentials, error) {
+// GetAssumeRoleCredentials gets the Federation Token from AWS.
+func GetAssumeRoleCredentials(awsClient Client, durationSeconds *int64, roleSessionName, roleArn *string) (*sts.Credentials, error) {
 	assumeRoleOutput, err := awsClient.AssumeRole(&sts.AssumeRoleInput{
 		DurationSeconds: durationSeconds,
 		RoleSessionName: roleSessionName,

--- a/pkg/provider/aws/sts_test.go
+++ b/pkg/provider/aws/sts_test.go
@@ -92,7 +92,7 @@ func TestGetAssumeRoleCredentials(t *testing.T) {
 			// after mocks is defined
 			defer mocks.mockCtrl.Finish()
 
-			creds, err := getAssumeRoleCredentials(mocks.mockAWSClient, aws.Int64(0), &tc.roleSessionName, &tc.roleArn)
+			creds, err := GetAssumeRoleCredentials(mocks.mockAWSClient, aws.Int64(0), &tc.roleSessionName, &tc.roleArn)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())
 			} else {


### PR DESCRIPTION
This PR aims to add the command `osdctl account cli` command that generates on-demand STS credentials for command line use, similar to the on-demand console url credential verification.