### PR TITLE
Return error when failing to list resources

### DIFF
--- a/cmd/account/get/account-claim.go
+++ b/cmd/account/get/account-claim.go
@@ -97,7 +97,7 @@ func (o *getAccountClaimOptions) run() error {
 		if err := o.kubeCli.List(ctx, &accounts, &client.ListOptions{
 			Namespace: o.accountNamespace,
 		}); err != nil {
-			return nil
+			return err
 		}
 
 		for _, a := range accounts.Items {

--- a/cmd/account/get/account.go
+++ b/cmd/account/get/account.go
@@ -116,7 +116,7 @@ func (o *getAccountOptions) run() error {
 		if err := o.kubeCli.List(ctx, &accounts, &client.ListOptions{
 			Namespace: o.accountNamespace,
 		}); err != nil {
-			return nil
+			return err
 		}
 
 		for _, a := range accounts.Items {


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

A bug fix. We should return error when failing to list reousrces