### PR TITLE
Remove deprecated cli-credentials and console-url secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,6 @@ osdctl account get secrets -i <Account ID>
 
 test-cr-osdmanagedadminsre-secret
 test-cr-secret
-test-cr-sre-cli-credentials
-test-cr-sre-console-url
 ```
 
 2. Get AWS Account ID

--- a/cmd/account/get/secrets.go
+++ b/cmd/account/get/secrets.go
@@ -21,8 +21,6 @@ import (
 const (
 	osdAdminSecret = "-osdmanagedadminsre-secret"
 	secret         = "-secret"
-	cliCredentials = "-sre-cli-credentials"
-	consoleURL     = "-sre-console-url"
 )
 
 // newCmdGetSecrets implements the get secrets command which get
@@ -104,10 +102,8 @@ func (o *getSecretsOptions) run() error {
 		return fmt.Errorf("Account matches for AWS Account ID %s not found\n", o.accountID)
 	}
 
-	secretSuffixes := []string{osdAdminSecret, secret, cliCredentials, consoleURL}
-	var (
-		secret v1.Secret
-	)
+	secretSuffixes := []string{osdAdminSecret, secret}
+	var secret v1.Secret
 	for _, suffix := range secretSuffixes {
 		if err := o.kubeCli.Get(ctx, types.NamespacedName{
 			Namespace: o.accountNamespace,


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

The two secrets are going to be removed in aws-account-operator, so it is not needed to have them.