### PR TITLE
Output OU Name instead of OU ID

### DIFF
--- a/cmd/cost/list.go
+++ b/cmd/cost/list.go
@@ -74,7 +74,7 @@ func listCostsUnderOU(OU *organizations.OrganizationalUnit, awsClient awsprovide
 		if err := getOUCostRecursive(&cost, childOU, awsClient, timePtr); err != nil {
 			return err
 		}
-		fmt.Printf("Cost of %s: %f\n", *childOU.Id, cost)
+		fmt.Printf("Cost of %s: %f\n", *childOU.Name, cost)
 	}
 
 	return nil


### PR DESCRIPTION
Outputs OU name instead of OU ID. For example, running `osdctl cost list —ou <OUid>` gives:

```
Cost of <OU Name>: <Spending>

Cost of child OUs:
Cost of <Child OU Name>: <Spending>
Cost of <Child OU Name>: <Spending>
Cost of <Child OU Name>: <Spending>
…
```

Whereas previously the command gives:

```
Cost of <OU ID>: <Spending>

Cost of child OUs:
Cost of <Child OU ID>: <Spending>
Cost of <Child OU ID>: <Spending>
Cost of <Child OU ID>: <Spending>
…
```