### PR TITLE
Output OU Name instead of OU ID

### DIFF
--- a/cmd/cost/create.go
+++ b/cmd/cost/create.go
@@ -30,10 +30,10 @@ func newCmdCreate(streams genericclioptions.IOStreams) *cobra.Command {
 				log.Fatalln("OU flag:", err)
 			}
 
-			//Get Organizational Unit
-			OU := organizations.OrganizationalUnit{Id: aws.String(OUid)}
+			//Get information regarding Organizational Unit
+			OU := getOU(awsClient, OUid)
 
-			if err := createCostCategory(&OUid, &OU, awsClient); err != nil {
+			if err := createCostCategory(&OUid, OU, awsClient); err != nil {
 				log.Fatalf("Error creating cost category for %s: %v", OUid, err)
 			}
 		},
@@ -79,7 +79,7 @@ func createCostCategory(OUid *string, OU *organizations.OrganizationalUnit, awsC
 		return err
 	}
 
-	fmt.Println("Created Cost Category for", *OUid)
+	fmt.Println("Created Cost Category for", *OU.Name, "OU")
 
 	return nil
 }

--- a/cmd/cost/get.go
+++ b/cmd/cost/get.go
@@ -27,21 +27,22 @@ func newCmdGet(streams genericclioptions.IOStreams) *cobra.Command {
 			awsClient, err := opsCost.initAWSClients()
 			cmdutil.CheckErr(err)
 
-			//Get Organizational Unit
-			OU := organizations.OrganizationalUnit{Id: aws.String(ops.ou)}
-			//Store cost
-			var cost float64
+			//Get information regarding Organizational Unit
+			OU := getOU(awsClient, ops.ou)
 
-			if ops.recursive { //Get cost of given OU by aggregating costs of all (including immediate) accounts under OU
-				if err := getOUCostRecursive(&cost, &OU, awsClient, &ops.time); err != nil {
+			var cost float64
+			var unit string
+
+			if ops.recursive {
+				if err := getOUCostRecursive(&cost, OU, awsClient, &ops.time); err != nil {
 					log.Fatalln("Error getting cost of OU recursively:", err)
 				}
-				fmt.Printf("Cost of %s recursively is: %f\n", ops.ou, cost)
-			} else { //Get cost of given OU by aggregating costs of only immediate accounts under given OU
-				if err := getOUCost(&cost, &OU, awsClient, &ops.time); err != nil {
+				fmt.Printf("Cost of %s OU recursively is: %f%s\n", *OU.Name, cost, unit)
+			} else {
+				if err := getOUCost(&cost, OU, awsClient, &ops.time); err != nil {
 					log.Fatalln("Error getting cost of OU:", err)
 				}
-				fmt.Printf("Cost of %s is: %f\n", ops.ou, cost)
+				fmt.Printf("Cost of %s OU is: %f%s\n", *OU.Name, cost, unit)
 			}
 		},
 	}

--- a/cmd/cost/list.go
+++ b/cmd/cost/list.go
@@ -7,7 +7,6 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"log"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/spf13/cobra"
 )
@@ -32,10 +31,10 @@ func newCmdList(streams genericclioptions.IOStreams) *cobra.Command {
 				log.Fatalln("Time flag:", err)
 			}
 
-			//Get Organizational Unit
-			OU := organizations.OrganizationalUnit{Id: aws.String(OUid)}
+			//Get information regarding Organizational Unit
+			OU := getOU(awsClient, OUid)
 
-			if err := listCostsUnderOU(&OU, awsClient, &time); err != nil {
+			if err := listCostsUnderOU(OU, awsClient, &time); err != nil {
 				log.Fatalln("Error listing costs under OU:", err)
 			}
 		},
@@ -64,9 +63,9 @@ func listCostsUnderOU(OU *organizations.OrganizationalUnit, awsClient awsprovide
 		return err
 	}
 	if len(OUs) != 0 {
-		fmt.Printf("Cost of %s: %f\n\nCost of child OUs:\n", *OU.Id, cost)
+		fmt.Printf("Cost of %s: %f\n\nCost of child OUs:\n", *OU.Name, cost)
 	} else {
-		fmt.Printf("Cost of %s: %f\nNo child OUs.\n", *OU.Id, cost)
+		fmt.Printf("Cost of %s: %f\nNo child OUs.\n", *OU.Name, cost)
 	}
 	//Print costs of child OUs under given OU
 	for _, childOU := range OUs {
@@ -74,7 +73,7 @@ func listCostsUnderOU(OU *organizations.OrganizationalUnit, awsClient awsprovide
 		if err := getOUCostRecursive(&cost, childOU, awsClient, timePtr); err != nil {
 			return err
 		}
-		fmt.Printf("Cost of %s: %f\n", *childOU.Id, cost)
+		fmt.Printf("Cost of %s: %f\n", *childOU.Name, cost)
 	}
 
 	return nil

--- a/cmd/cost/reconcile.go
+++ b/cmd/cost/reconcile.go
@@ -2,7 +2,6 @@ package cost
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/costexplorer"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/deckarep/golang-set"
@@ -29,10 +28,10 @@ func newCmdReconcile(streams genericclioptions.IOStreams) *cobra.Command {
 				log.Fatalln("OU flag:", err)
 			}
 
-			//Set OU as Openshift: reconciliateCostCategories will then create cost categories for v4 and its child OUs
-			OU := organizations.OrganizationalUnit{Id: aws.String(OUid)}
+			//Get information regarding Organizational Unit
+			OU := getOU(awsClient, OUid)
 
-			if err := reconcileCostCategories(&OU, awsClient); err != nil {
+			if err := reconcileCostCategories(OU, awsClient); err != nil {
 				log.Fatalln("Error reconciling cost categories:", err)
 			}
 		},

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -63,6 +63,7 @@ type Client interface {
 	// Organizations
 	ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error)
 	ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
+	DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error)
 
 	// Cost Explorer
 	GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error)
@@ -225,6 +226,10 @@ func (c *AwsClient) ListAccountsForParent(input *organizations.ListAccountsForPa
 
 func (c *AwsClient) ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error) {
 	return c.orgClient.ListOrganizationalUnitsForParent(input)
+}
+
+func (c *AwsClient) DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error) {
+	return c.orgClient.DescribeOrganizationalUnit(input)
 }
 
 func (c *AwsClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error) {

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -353,6 +353,21 @@ func (mr *MockClientMockRecorder) ListOrganizationalUnitsForParent(input interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationalUnitsForParent", reflect.TypeOf((*MockClient)(nil).ListOrganizationalUnitsForParent), input)
 }
 
+// DescribeOrganizationalUnit mocks base method.
+func (m *MockClient) DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeOrganizationalUnit", input)
+	ret0, _ := ret[0].(*organizations.DescribeOrganizationalUnitOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeOrganizationalUnit indicates an expected call of DescribeOrganizationalUnit.
+func (mr *MockClientMockRecorder) DescribeOrganizationalUnit(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeOrganizationalUnit", reflect.TypeOf((*MockClient)(nil).DescribeOrganizationalUnit), input)
+}
+
 // GetCostAndUsage mocks base method.
 func (m *MockClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Outputs OU name instead of OU ID. For example, running `osdctl cost list —ou <OUid>` gives:
```
Cost of <OU Name>: <Spending>

Cost of child OUs:
Cost of <Child OU Name>: <Spending>
Cost of <Child OU Name>: <Spending>
Cost of <Child OU Name>: <Spending>
…
```

Whereas previously the command gives:
```
Cost of <OU ID>: <Spending>

Cost of child OUs:
Cost of <Child OU ID>: <Spending>
Cost of <Child OU ID>: <Spending>
Cost of <Child OU ID>: <Spending>
…
```