### PR TITLE
CSV output and unit tests for create.go and reconcile.go

### DIFF
--- a/cmd/cost/create.go
+++ b/cmd/cost/create.go
@@ -79,7 +79,7 @@ func createCostCategory(OUid *string, OU *organizations.OrganizationalUnit, awsC
 		return err
 	}
 
-	fmt.Println("Created Cost Category for", *OU.Name, "OU")
+	fmt.Printf("Created Cost Category for %s (%s) OU\n", *OU.Name, *OU.Id)
 
 	return nil
 }

--- a/cmd/cost/create_test.go
+++ b/cmd/cost/create_test.go
@@ -1,0 +1,140 @@
+package cost
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/golang/mock/gomock"
+	"github.com/onsi/gomega"
+	"github.com/openshift/osd-utils-cli/pkg/provider/aws/mock"
+	"testing"
+)
+
+type mockSuite struct {
+	mockCtrl      *gomock.Controller
+	mockAWSClient *mock.MockClient
+}
+
+func setupDefaultMocks(t *testing.T) *mockSuite {
+	mocks := &mockSuite{
+		mockCtrl: gomock.NewController(t),
+	}
+
+	mocks.mockAWSClient = mock.NewMockClient(mocks.mockCtrl)
+	return mocks
+}
+
+func TestCreateCostCategory(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	testCases := []struct {
+		title        string
+		setupAWSMock func(r *mock.MockClientMockRecorder)
+		OUid         *string
+		name         *string
+		errExpected  bool
+	}{
+		{
+			title: "ListOrganizationalUnitsForParent Returns Error",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				r.ListOrganizationalUnitsForParent(gomock.Any()).Return(nil, errors.New("FakeError")).Times(1)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: true,
+		},
+		{
+			title: "ListAccountsForParent Returns Error",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				gomock.InOrder(
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListAccountsForParent(gomock.Any()).Return(nil, errors.New("FakeError")).Times(1),
+				)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: true,
+		},
+		{
+			title: "CreateCostCategoryDefinition Fails",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				gomock.InOrder(
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListAccountsForParent(gomock.Any()).Return(
+						&organizations.ListAccountsForParentOutput{
+							NextToken: nil,
+							Accounts:  []*organizations.Account{},
+						}, nil).Times(1),
+
+					r.CreateCostCategoryDefinition(gomock.Any()).Return(nil, errors.New("FakeError")).Times(1),
+				)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: true,
+		},
+		{
+			title: "CreateCostCategoryDefinition Succeeds",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				gomock.InOrder(
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListAccountsForParent(gomock.Any()).Return(
+						&organizations.ListAccountsForParentOutput{
+							NextToken: nil,
+							Accounts: []*organizations.Account{
+								{
+									Id:   aws.String("Account ID"),
+									Name: aws.String("Account Name"),
+								},
+							},
+						}, nil).Times(1),
+
+					r.CreateCostCategoryDefinition(gomock.Any()).Return(
+						&costexplorer.CreateCostCategoryDefinitionOutput{
+							CostCategoryArn: aws.String("Placeholder Arn"),
+							EffectiveStart:  aws.String("Placeholder Start"),
+						}, nil).Times(1),
+				)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: false,
+		},
+	}
+
+	//Go through test cases
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			mocks := setupDefaultMocks(t)
+			tc.setupAWSMock(mocks.mockAWSClient.EXPECT())
+
+			defer mocks.mockCtrl.Finish()
+
+			OU := &organizations.OrganizationalUnit{Id: tc.OUid, Name: tc.name}
+
+			err := createCostCategory(tc.OUid, OU, mocks.mockAWSClient)
+
+			if tc.errExpected {
+				g.Expect(err).Should(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+			}
+		})
+	}
+}

--- a/cmd/cost/get.go
+++ b/cmd/cost/get.go
@@ -50,6 +50,10 @@ func newCmdGet(streams genericclioptions.IOStreams) *cobra.Command {
 	getCmd.Flags().StringVarP(&ops.time, "time", "t", "", "set time")
 	getCmd.Flags().BoolVar(&ops.csv, "csv", false, "output result as csv")
 
+	if err := getCmd.MarkFlagRequired("ou"); err != nil {
+		log.Fatalln("OU flag:", err)
+	}
+
 	return getCmd
 }
 

--- a/cmd/cost/get.go
+++ b/cmd/cost/get.go
@@ -33,26 +33,22 @@ func newCmdGet(streams genericclioptions.IOStreams) *cobra.Command {
 			var cost float64
 			var unit string
 
-			if ops.recursive {
-				if err := getOUCostRecursive(&cost, OU, awsClient, &ops.time); err != nil {
+			if ops.recursive { //Get cost of given OU by aggregating costs of all (including immediate) accounts under OU
+				if err := getOUCostRecursive(&cost, &unit, OU, awsClient, &ops.time); err != nil {
 					log.Fatalln("Error getting cost of OU recursively:", err)
 				}
-				fmt.Printf("Cost of %s OU recursively is: %f%s\n", *OU.Name, cost, unit)
-			} else {
-				if err := getOUCost(&cost, OU, awsClient, &ops.time); err != nil {
+			} else { //Get cost of given OU by aggregating costs of only immediate accounts under given OU
+				if err := getOUCost(&cost, &unit, OU, awsClient, &ops.time); err != nil {
 					log.Fatalln("Error getting cost of OU:", err)
 				}
-				fmt.Printf("Cost of %s OU is: %f%s\n", *OU.Name, cost, unit)
 			}
+			printCostGet(cost, unit, ops, OU)
 		},
 	}
+	getCmd.Flags().StringVar(&ops.ou, "ou", "", "get OU ID")
 	getCmd.Flags().BoolVarP(&ops.recursive, "recursive", "r", false, "recurse through OUs")
 	getCmd.Flags().StringVarP(&ops.time, "time", "t", "", "set time")
-	getCmd.Flags().StringVar(&ops.ou, "ou", "", "get OU ID")
-
-	if err := getCmd.MarkFlagRequired("ou"); err != nil {
-		log.Fatalln("OU flag:", err)
-	}
+	getCmd.Flags().BoolVar(&ops.csv, "csv", false, "output result as csv")
 
 	return getCmd
 }
@@ -62,6 +58,7 @@ type getOptions struct {
 	ou        string
 	recursive bool
 	time      string
+	csv       bool
 
 	genericclioptions.IOStreams
 }
@@ -175,7 +172,7 @@ func getOUsRecursive(OU *organizations.OrganizationalUnit, awsClient awsprovider
 }
 
 //Get cost of given account
-func getAccountCost(accountID *string, awsClient awsprovider.Client, timePtr *string, cost *float64) error {
+func getAccountCost(accountID *string, unit *string, awsClient awsprovider.Client, timePtr *string, cost *float64) error {
 
 	start, end := getTimePeriod(timePtr)
 	granularity := "MONTHLY"
@@ -213,11 +210,14 @@ func getAccountCost(accountID *string, awsClient awsprovider.Client, timePtr *st
 		*cost += monthCost
 	}
 
+	//Save unit
+	*unit = *costs.ResultsByTime[0].Total["NetUnblendedCost"].Unit
+
 	return nil
 }
 
 //Get cost of given OU by aggregating costs of only immediate accounts under given OU
-func getOUCost(cost *float64, OU *organizations.OrganizationalUnit, awsClient awsprovider.Client, timePtr *string) error {
+func getOUCost(cost *float64, unit *string, OU *organizations.OrganizationalUnit, awsClient awsprovider.Client, timePtr *string) error {
 	//Populate accounts
 	accounts, err := getAccounts(OU, awsClient)
 	if err != nil {
@@ -226,7 +226,7 @@ func getOUCost(cost *float64, OU *organizations.OrganizationalUnit, awsClient aw
 
 	//Increment costs of accounts
 	for _, account := range accounts {
-		if err := getAccountCost(account, awsClient, timePtr, cost); err != nil {
+		if err := getAccountCost(account, unit, awsClient, timePtr, cost); err != nil {
 			return err
 		}
 	}
@@ -235,7 +235,7 @@ func getOUCost(cost *float64, OU *organizations.OrganizationalUnit, awsClient aw
 }
 
 //Get cost of given OU by aggregating costs of all (including immediate) accounts under OU
-func getOUCostRecursive(cost *float64, OU *organizations.OrganizationalUnit, awsClient awsprovider.Client, timePtr *string) error {
+func getOUCostRecursive(cost *float64, unit *string, OU *organizations.OrganizationalUnit, awsClient awsprovider.Client, timePtr *string) error {
 	//Populate OUs
 	OUs, err := getOUs(OU, awsClient)
 	if err != nil {
@@ -244,13 +244,13 @@ func getOUCostRecursive(cost *float64, OU *organizations.OrganizationalUnit, aws
 
 	//Loop through all child OUs, get their costs, and store it to cost of current OU
 	for _, childOU := range OUs {
-		if err := getOUCostRecursive(cost, childOU, awsClient, timePtr); err != nil {
+		if err := getOUCostRecursive(cost, unit, childOU, awsClient, timePtr); err != nil {
 			return err
 		}
 	}
 
 	//Return cost of child OUs + cost of immediate accounts under current OU
-	if err := getOUCost(cost, OU, awsClient, timePtr); err != nil {
+	if err := getOUCost(cost, unit, OU, awsClient, timePtr); err != nil {
 		return err
 	}
 
@@ -290,4 +290,16 @@ func getTimePeriod(timePtr *string) (string, string) {
 	}
 
 	return start, end
+}
+
+func printCostGet(cost float64, unit string, ops *getOptions, OU *organizations.OrganizationalUnit) {
+	if ops.csv { //If csv option specified, print result in csv
+		fmt.Printf("\n%s,%f (%s)\n\n", *OU.Name, cost, unit)
+	} else if ops.recursive {
+		//fmt.Printf("\nCost of %s OU recursively is: %f %s\n\n", *OU.Name, cost, unit)
+		fmt.Printf("\nCost of all accounts under OU (%s, %s):\n%f %s\n\n", *OU.Id, *OU.Name, cost, unit)
+	} else {
+		//fmt.Printf("\nCost of %s OU is: %f %s\n\n", *OU.Name, cost, unit)
+		fmt.Printf("\nCost of OU: (%s, %s):\n%f %s\n\n", *OU.Id, *OU.Name, cost, unit)
+	}
 }

--- a/cmd/cost/list.go
+++ b/cmd/cost/list.go
@@ -29,18 +29,22 @@ func newCmdList(streams genericclioptions.IOStreams) *cobra.Command {
 			}
 		},
 	}
-	listCmd.Flags().StringVar(&ops.ou, "ou", "ou-0wd6-aff5ji37", "get name of OU (default is name of v4's OU)")
+	listCmd.Flags().StringVar(&ops.ou, "ou", "", "get OU ID")
 	listCmd.Flags().StringVarP(&ops.time, "time", "t", "", "set time")
 	listCmd.Flags().BoolVar(&ops.csv, "csv", false, "output result as csv")
+
+	if err := listCmd.MarkFlagRequired("ou"); err != nil {
+		log.Fatalln("OU flag:", err)
+	}
 
 	return listCmd
 }
 
 //Store flag options for get command
 type listOptions struct {
-	ou        string
-	time      string
-	csv       bool
+	ou   string
+	time string
+	csv  bool
 
 	genericclioptions.IOStreams
 }

--- a/cmd/cost/list.go
+++ b/cmd/cost/list.go
@@ -13,6 +13,7 @@ import (
 
 // listCmd represents the list command
 func newCmdList(streams genericclioptions.IOStreams) *cobra.Command {
+	ops := newListOptions(streams)
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the cost of each OU under given OU",
@@ -21,60 +22,80 @@ func newCmdList(streams genericclioptions.IOStreams) *cobra.Command {
 			awsClient, err := opsCost.initAWSClients()
 			cmdutil.CheckErr(err)
 
-			//Get flags
-			OUid, err := cmd.Flags().GetString("ou")
-			if err != nil {
-				log.Fatalln("OU flag:", err)
-			}
-			time, err := cmd.Flags().GetString("time")
-			if err != nil {
-				log.Fatalln("Time flag:", err)
-			}
+			OU := getOU(awsClient, ops.ou)
 
-			//Get information regarding Organizational Unit
-			OU := getOU(awsClient, OUid)
-
-			if err := listCostsUnderOU(OU, awsClient, &time); err != nil {
+			if err := listCostsUnderOU(OU, awsClient, ops); err != nil {
 				log.Fatalln("Error listing costs under OU:", err)
 			}
 		},
 	}
-	listCmd.Flags().StringP("time", "t", "", "set time")
-	listCmd.Flags().String("ou", "", "get OU ID")
-
-	if err := listCmd.MarkFlagRequired("ou"); err != nil {
-		log.Fatalln("OU flag:", err)
-	}
+	listCmd.Flags().StringVar(&ops.ou, "ou", "ou-0wd6-aff5ji37", "get name of OU (default is name of v4's OU)")
+	listCmd.Flags().StringVarP(&ops.time, "time", "t", "", "set time")
+	listCmd.Flags().BoolVar(&ops.csv, "csv", false, "output result as csv")
 
 	return listCmd
 }
 
+//Store flag options for get command
+type listOptions struct {
+	ou        string
+	time      string
+	csv       bool
+
+	genericclioptions.IOStreams
+}
+
+func newListOptions(streams genericclioptions.IOStreams) *listOptions {
+	return &listOptions{
+		IOStreams: streams,
+	}
+}
+
 //List the cost of each OU under given OU
-func listCostsUnderOU(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client, timePtr *string) error {
+func listCostsUnderOU(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client, ops *listOptions) error {
 	OUs, err := getOUsRecursive(OU, awsClient)
 	if err != nil {
 		return err
 	}
 
 	var cost float64
+	var unit string
+	var isChildNode bool
 
-	//Print total cost for given OU
-	if err := getOUCostRecursive(&cost, OU, awsClient, timePtr); err != nil {
+	if err := getOUCostRecursive(&cost, &unit, OU, awsClient, &ops.time); err != nil {
 		return err
 	}
-	if len(OUs) != 0 {
-		fmt.Printf("Cost of %s: %f\n\nCost of child OUs:\n", *OU.Name, cost)
-	} else {
-		fmt.Printf("Cost of %s: %f\nNo child OUs.\n", *OU.Name, cost)
-	}
+
+	//Print cost of given OU
+	printCostList(cost, unit, OU, ops, isChildNode)
+
 	//Print costs of child OUs under given OU
 	for _, childOU := range OUs {
 		cost = 0
-		if err := getOUCostRecursive(&cost, childOU, awsClient, timePtr); err != nil {
+		isChildNode = true
+
+		if err := getOUCostRecursive(&cost, &unit, childOU, awsClient, &ops.time); err != nil {
 			return err
 		}
-		fmt.Printf("Cost of %s: %f\n", *childOU.Name, cost)
+		printCostList(cost, unit, childOU, ops, isChildNode)
 	}
 
 	return nil
+}
+
+func printCostList(cost float64, unit string, OU *organizations.OrganizationalUnit, ops *listOptions, isChildNode bool) {
+	if !isChildNode {
+		if ops.csv {
+			fmt.Printf("\nOU,Cost(%s)\n%v,%f\n", unit, *OU.Name, cost)
+		} else {
+			fmt.Printf("\nListing costs of OU (%s, %s) and all its child OUs:\n\n", *OU.Id, *OU.Name)
+			fmt.Printf("%-30s%-30s%-30s%-30s\n", "OU ID", "OU Name", "Cost", "Unit")
+		}
+	}
+
+	if ops.csv {
+		fmt.Printf("%v,%f\n", *OU.Name, cost)
+	} else {
+		fmt.Printf("%-30s%-30s%-30f%-30s\n", *OU.Id, *OU.Name, cost, unit)
+	}
 }

--- a/cmd/cost/reconcile.go
+++ b/cmd/cost/reconcile.go
@@ -58,7 +58,7 @@ func reconcileCostCategories(OU *organizations.OrganizationalUnit, awsClient aws
 		})
 
 		if err != nil {
-			log.Fatalln("Error listing cost categories:", err)
+			return err
 		}
 
 		//Loop through and add to costCategoriesSet. Set makes lookup easier

--- a/cmd/cost/reconcile_test.go
+++ b/cmd/cost/reconcile_test.go
@@ -1,0 +1,164 @@
+package cost
+
+import (
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+
+	//"github.com/aws/aws-sdk-go/service/costexplorer"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/golang/mock/gomock"
+	"github.com/onsi/gomega"
+	"github.com/openshift/osd-utils-cli/pkg/provider/aws/mock"
+	"testing"
+)
+
+func TestReconcileCostCategories(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	testCases := []struct {
+		title        string
+		setupAWSMock func(r *mock.MockClientMockRecorder)
+		OUid         *string
+		name         *string
+		errExpected  bool
+	}{
+		{
+			title: "ListCostCategoryDefinitions Returns Error",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				r.ListCostCategoryDefinitions(gomock.Any()).Return(nil, errors.New("FakeError")).Times(1)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: true,
+		},
+		{
+			title: "ListOrganizationalUnitsForParent Returns Error",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				gomock.InOrder(
+					r.ListCostCategoryDefinitions(gomock.Any()).Return(
+						&costexplorer.ListCostCategoryDefinitionsOutput{
+							CostCategoryReferences: []*costexplorer.CostCategoryReference{{Name: aws.String("CostCategory1")}},
+							NextToken:              aws.String("FakeToken"),
+						}, nil).Times(1),
+
+					r.ListCostCategoryDefinitions(gomock.Any()).Return(
+						&costexplorer.ListCostCategoryDefinitionsOutput{}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(nil, errors.New("FakeError")).Times(1),
+				)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: true,
+		},
+		{
+			title: "ListAccountsForParent Returns Error",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				gomock.InOrder(
+					r.ListCostCategoryDefinitions(gomock.Any()).Return(
+						&costexplorer.ListCostCategoryDefinitionsOutput{}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken: aws.String("FakeToken"),
+							OrganizationalUnits: []*organizations.OrganizationalUnit{
+								{
+									Id:   aws.String("FakeID"),
+									Name: aws.String("FakeName"),
+								},
+							},
+						}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListAccountsForParent(gomock.Any()).Return(nil, errors.New("FakeError")).Times(1),
+				)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: true,
+		},
+		{
+			title: "ListAccountsForParent Succeeds",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				gomock.InOrder(
+					r.ListCostCategoryDefinitions(gomock.Any()).Return(
+						&costexplorer.ListCostCategoryDefinitionsOutput{}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken: aws.String("FakeToken"),
+							OrganizationalUnits: []*organizations.OrganizationalUnit{
+								{
+									Id:   aws.String("FakeID"),
+									Name: aws.String("FakeName"),
+								},
+							},
+						}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListOrganizationalUnitsForParent(gomock.Any()).Return(
+						&organizations.ListOrganizationalUnitsForParentOutput{
+							NextToken:           nil,
+							OrganizationalUnits: []*organizations.OrganizationalUnit{},
+						}, nil).Times(1),
+
+					r.ListAccountsForParent(gomock.Any()).Return(&organizations.ListAccountsForParentOutput{}, nil).Times(1),
+
+					r.CreateCostCategoryDefinition(gomock.Any()).Return(nil, nil).Times(1),
+				)
+			},
+			OUid:        aws.String("ou-9999-99999999"),
+			name:        aws.String("Random OU"),
+			errExpected: false,
+		},
+	}
+
+	//Go through test cases
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			mocks := setupDefaultMocks(t)
+			tc.setupAWSMock(mocks.mockAWSClient.EXPECT())
+
+			defer mocks.mockCtrl.Finish()
+
+			OU := &organizations.OrganizationalUnit{Id: tc.OUid, Name: tc.name}
+
+			err := reconcileCostCategories(OU, mocks.mockAWSClient)
+
+			if tc.errExpected {
+				g.Expect(err).Should(gomega.HaveOccurred())
+			} else {
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+			}
+		})
+	}
+}

--- a/docs/command/osdctl_cost_get.md
+++ b/docs/command/osdctl_cost_get.md
@@ -13,6 +13,7 @@ osdctl cost get [flags]
 ### Options
 
 ```
+      --csv           output result as csv
   -h, --help          help for get
       --ou string     get OU ID
   -r, --recursive     recurse through OUs

--- a/docs/command/osdctl_cost_list.md
+++ b/docs/command/osdctl_cost_list.md
@@ -13,6 +13,7 @@ osdctl cost list [flags]
 ### Options
 
 ```
+      --csv           output result as csv
   -h, --help          help for list
       --ou string     get OU ID
   -t, --time string   set time


### PR DESCRIPTION
Added CSV output option for viewing costs.

Wrote unit tests for create.go and reconcile.go.