### PR TITLE
Add higher level secret command and move related commands into it

### DIFF
--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/osd-utils-cli/cmd/account/get"
 	"github.com/openshift/osd-utils-cli/cmd/account/list"
+	"github.com/openshift/osd-utils-cli/cmd/account/secret"
 )
 
 // NewCmdAccount implements the base account command
@@ -20,13 +21,13 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 
 	accountCmd.AddCommand(get.NewCmdGet(streams, flags))
 	accountCmd.AddCommand(list.NewCmdList(streams, flags))
+	accountCmd.AddCommand(secret.NewCmdSecret(streams, flags))
+
 	accountCmd.AddCommand(newCmdReset(streams, flags))
 	accountCmd.AddCommand(newCmdSet(streams, flags))
 	accountCmd.AddCommand(newCmdConsole(streams, flags))
 	accountCmd.AddCommand(newCmdCli(streams, flags))
 	accountCmd.AddCommand(newCmdCleanVeleroSnapshots(streams))
-	accountCmd.AddCommand(newCmdCheckSecrets(streams, flags))
-	accountCmd.AddCommand(newCmdRotateSecret(streams, flags))
 
 	return accountCmd
 }

--- a/cmd/account/secret/check.go
+++ b/cmd/account/secret/check.go
@@ -1,4 +1,4 @@
-package account
+package secret
 
 import (
 	"context"
@@ -27,7 +27,7 @@ const (
 func newCmdCheckSecrets(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
 	ops := newCheckSecretsOptions(streams, flags)
 	checkSecretsCmd := &cobra.Command{
-		Use:               "check-secrets [<account name>]",
+		Use:               "check [<account name>]",
 		Short:             "Check AWS Account CR IAM User credentials",
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/account/secret/check_test.go
+++ b/cmd/account/secret/check_test.go
@@ -1,4 +1,4 @@
-package account
+package secret
 
 import (
 	"os"

--- a/cmd/account/secret/cmd.go
+++ b/cmd/account/secret/cmd.go
@@ -1,0 +1,29 @@
+package secret
+
+import (
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	accountIDRequired = "AWS Account ID is required. You can use -i or --account-id to specify it"
+)
+
+// NewCmdSecret implements the secret command
+func NewCmdSecret(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	secretCmd := &cobra.Command{
+		Use:               "secret",
+		Short:             "secret <command>",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run:               help,
+	}
+	secretCmd.AddCommand(newCmdCheckSecrets(streams, flags))
+	secretCmd.AddCommand(newCmdRotateSecret(streams, flags))
+	return secretCmd
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	cmd.Help()
+}

--- a/cmd/account/secret/rotate.go
+++ b/cmd/account/secret/rotate.go
@@ -1,4 +1,4 @@
-package account
+package secret
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 func newCmdRotateSecret(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
 	ops := newRotateSecretOptions(streams, flags)
 	rotateSecretCmd := &cobra.Command{
-		Use:               "rotate-secret <IAM User name>",
+		Use:               "rotate <IAM User name>",
 		Short:             "Rotate IAM credentials secret",
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/docs/command/osdctl_account_secret.md
+++ b/docs/command/osdctl_account_secret.md
@@ -1,0 +1,35 @@
+## osdctl account secret
+
+secret <command>
+
+### Synopsis
+
+secret <command>
+
+```
+osdctl account secret [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for secret
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
+```
+
+### SEE ALSO
+
+* [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+* [osdctl account secret check](osdctl_account_secret_check.md)	 - Check AWS Account CR IAM User credentials
+* [osdctl account secret rotate](osdctl_account_secret_rotate.md)	 - Rotate IAM credentials secret
+

--- a/docs/command/osdctl_account_secret_check.md
+++ b/docs/command/osdctl_account_secret_check.md
@@ -1,19 +1,21 @@
-## osdctl account
+## osdctl account secret check
 
-AWS Account related utilities
+Check AWS Account CR IAM User credentials
 
 ### Synopsis
 
-AWS Account related utilities
+Check AWS Account CR IAM User credentials
 
 ```
-osdctl account [flags]
+osdctl account secret check [<account name>] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for account
+      --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -h, --help                       help for check
+  -v, --verbose                    Verbose output
 ```
 
 ### Options inherited from parent commands
@@ -29,13 +31,5 @@ osdctl account [flags]
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
-* [osdctl account clean-velero-snapshots](osdctl_account_clean-velero-snapshots.md)	 - Cleans up S3 buckets whose name start with managed-velero
-* [osdctl account cli](osdctl_account_cli.md)	 - Generate temporary AWS CLI credentials on demand
-* [osdctl account console](osdctl_account_console.md)	 - Generate an AWS console URL on the fly
-* [osdctl account get](osdctl_account_get.md)	 - get resources
-* [osdctl account list](osdctl_account_list.md)	 - List resources
-* [osdctl account reset](osdctl_account_reset.md)	 - Reset AWS Account CR
 * [osdctl account secret](osdctl_account_secret.md)	 - secret <command>
-* [osdctl account set](osdctl_account_set.md)	 - Set AWS Account CR status
 

--- a/docs/command/osdctl_account_secret_rotate.md
+++ b/docs/command/osdctl_account_secret_rotate.md
@@ -1,0 +1,43 @@
+## osdctl account secret rotate
+
+Rotate IAM credentials secret
+
+### Synopsis
+
+Rotate IAM credentials secret
+
+```
+osdctl account secret rotate <IAM User name> [flags]
+```
+
+### Options
+
+```
+  -i, --account-id string          AWS Account ID
+  -a, --account-name string        AWS Account CR name
+      --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -c, --aws-config string          specify AWS config file path
+  -p, --aws-profile string         specify AWS profile
+  -r, --aws-region string          Specify AWS region (default "us-east-1")
+  -h, --help                       help for rotate
+  -o, --output string              Output path for secret yaml file
+      --print                      Print the generated secret (default true)
+      --secret-name string         Specify name of the generated secret (default "byoc")
+      --secret-namespace string    Specify namespace of the generated secret (default "aws-account-operator")
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
+```
+
+### SEE ALSO
+
+* [osdctl account secret](osdctl_account_secret.md)	 - secret <command>
+


### PR DESCRIPTION
This has no card and no priority. 
Since we had more than one command related to secrets I thought it made sense to move them into a secret specific command.