### PR TITLE
check-secrets -> verify-secrets, add CCS validation

### DIFF
--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -25,7 +25,7 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 	accountCmd.AddCommand(newCmdConsole(streams, flags))
 	accountCmd.AddCommand(newCmdCli(streams, flags))
 	accountCmd.AddCommand(newCmdCleanVeleroSnapshots(streams))
-	accountCmd.AddCommand(newCmdCheckSecrets(streams, flags))
+	accountCmd.AddCommand(newCmdVerifySecrets(streams, flags))
 	accountCmd.AddCommand(newCmdRotateSecret(streams, flags))
 
 	return accountCmd

--- a/cmd/account/verify-secrets_test.go
+++ b/cmd/account/verify-secrets_test.go
@@ -16,7 +16,7 @@ func TestCheckSecretsCmdComplete(t *testing.T) {
 	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {
 		title       string
-		option      *checkSecretsOptions
+		option      *verifySecretsOptions
 		args        []string
 		errExpected bool
 		errContent  string
@@ -25,11 +25,11 @@ func TestCheckSecretsCmdComplete(t *testing.T) {
 			title:       "two args provided",
 			args:        []string{"foo", "bar"},
 			errExpected: true,
-			errContent:  checkSecretsUsage,
+			errContent:  verifySecretsUsage,
 		},
 		{
 			title: "succeed with one arg",
-			option: &checkSecretsOptions{
+			option: &verifySecretsOptions{
 				accountName: "foo",
 				flags:       kubeFlags,
 			},
@@ -38,7 +38,7 @@ func TestCheckSecretsCmdComplete(t *testing.T) {
 		},
 		{
 			title: "succeed with one arg",
-			option: &checkSecretsOptions{
+			option: &verifySecretsOptions{
 				flags: kubeFlags,
 			},
 			args:        []string{},
@@ -48,7 +48,7 @@ func TestCheckSecretsCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdCheckSecrets(streams, kubeFlags)
+			cmd := newCmdVerifySecrets(streams, kubeFlags)
 			err := tc.option.complete(cmd, tc.args)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/docs/command/osdctl_account.md
+++ b/docs/command/osdctl_account.md
@@ -30,7 +30,6 @@ osdctl account [flags]
 ### SEE ALSO
 
 * [osdctl](osdctl.md)	 - OSD CLI
-* [osdctl account check-secrets](osdctl_account_check-secrets.md)	 - Check AWS Account CR IAM User credentials
 * [osdctl account clean-velero-snapshots](osdctl_account_clean-velero-snapshots.md)	 - Cleans up S3 buckets whose name start with managed-velero
 * [osdctl account cli](osdctl_account_cli.md)	 - Generate temporary AWS CLI credentials on demand
 * [osdctl account console](osdctl_account_console.md)	 - Generate an AWS console URL on the fly
@@ -39,4 +38,5 @@ osdctl account [flags]
 * [osdctl account reset](osdctl_account_reset.md)	 - Reset AWS Account CR
 * [osdctl account rotate-secret](osdctl_account_rotate-secret.md)	 - Rotate IAM credentials secret
 * [osdctl account set](osdctl_account_set.md)	 - Set AWS Account CR status
+* [osdctl account verify-secrets](osdctl_account_verify-secrets.md)	 - Verify AWS Account CR IAM User credentials
 

--- a/docs/command/osdctl_account_verify-secrets.md
+++ b/docs/command/osdctl_account_verify-secrets.md
@@ -1,0 +1,36 @@
+## osdctl account verify-secrets
+
+Verify AWS Account CR IAM User credentials
+
+### Synopsis
+
+Verify AWS Account CR IAM User credentials
+
+```
+osdctl account verify-secrets [<account name>] [flags]
+```
+
+### Options
+
+```
+      --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -A, --all                        Verify all Account CRs
+  -h, --help                       help for verify-secrets
+  -v, --verbose                    Verbose output
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
+```
+
+### SEE ALSO
+
+* [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+


### PR DESCRIPTION
The PR does the following:
1. Changes `osdctl account check-secrets` to `osdctl account verify-secrets`
2. Changes the default behaviour to expect an Account CR name
3. Adds the `-A` option to validate all Account CR's secrets
4. Adds the BYOC secret to be validated if the Account CR has BYOC as true

From the done criteria:
`output command necessary to reset invalid credentials (action to be added)` 
This is not done as it relies on upcoming changes to generate new secrets, and can be done as part of that PR instead. 