### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,9 @@
-GOOS := $(if $(GOOS),$(GOOS),linux)
-GOARCH := $(if $(GOARCH),$(GOARCH),amd64)
-GO=CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) GO111MODULE=on go
-GOVERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1)
-
-REPOSITORY = github.com/openshift/osd-utils-cli
-
+REPOSITORY = $(shell go list -m)
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 
 BUILDFLAGS ?=
 LDFLAGS = -ldflags="-X '${REPOSITORY}/cmd.GitCommit=${GIT_COMMIT}'"
-
-ifeq ($(shell expr ${GOVERSION} \>= 1.14), 1)
-	BUILDFLAGS += -mod=mod
-endif
-
-PACKAGE_LIST  := go list ./...
-PACKAGES  := $$($(PACKAGE_LIST))
-FILES_TO_FMT  := $(shell find . -path -prune -o -name '*.go' -print)
+unexport GOFLAGS
 
 all: format build test
 
@@ -24,18 +11,17 @@ format: vet fmt mockgen docs
 
 fmt:
 	@echo "gofmt"
-	@gofmt -w ${FILES_TO_FMT}
+	@gofmt -w -s .
 	@git diff --exit-code .
 
 build: mod
-	$(GO) build ${BUILDFLAGS} ${LDFLAGS} -o ./bin/osdctl main.go
+	go build ${BUILDFLAGS} ${LDFLAGS} -o ./bin/osdctl main.go
 
 vet:
-	$(GO) vet ${BUILDFLAGS} ./...
+	go vet ${BUILDFLAGS} ./...
 
 mod:
-	@echo "go mod tidy"
-	$(GO) mod tidy
+	go mod tidy
 	@git diff --exit-code -- go.mod
 
 docs: build
@@ -43,11 +29,11 @@ docs: build
 	@git diff --exit-code -- ./docs/command/
 
 mockgen: ensure-mockgen
-	$(GO) generate ${BUILDFLAGS} ./...
+	go generate ${BUILDFLAGS} ./...
 	@git diff --exit-code -- ./pkg/provider/aws/mock
 
 ensure-mockgen:
-	GO111MODULE=off go get -u github.com/golang/mock/mockgen
+	go get github.com/golang/mock/mockgen@v1.4.4
 
 test:
-	$(GO) test ${BUILDFLAGS} ./... -cover $(PACKAGES)
+	go test ${BUILDFLAGS} ./... -covermode=atomic -coverpkg=./...

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.31.10
 	github.com/deckarep/golang-set v1.7.1
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/golang/mock v1.4.3
+	github.com/golang/mock v1.4.4
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/aws-account-operator v0.0.0-20200914143350-bbda1c91242b

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,8 @@ github.com/golang/mock v1.0.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
-github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
-github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
+github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -2152,7 +2152,6 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -2561,8 +2560,6 @@ mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskX
 mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZIVpwbkw+04kSxk3rAtzlimaUJw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
-rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
-rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/controller-runtime v0.0.0-20190520212815-96b67f231945/go.mod h1:TSH2R0nSz4WAlUUlNnOFcOR/VUhfwBLlmtq2X6AiQCA=
 sigs.k8s.io/controller-runtime v0.2.0-beta.2/go.mod h1:TSH2R0nSz4WAlUUlNnOFcOR/VUhfwBLlmtq2X6AiQCA=

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -5,40 +5,39 @@
 package mock
 
 import (
-	reflect "reflect"
-
 	costexplorer "github.com/aws/aws-sdk-go/service/costexplorer"
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	organizations "github.com/aws/aws-sdk-go/service/organizations"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	sts "github.com/aws/aws-sdk-go/service/sts"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface.
+// MockClient is a mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient.
+// MockClientMockRecorder is the mock recorder for MockClient
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance.
+// NewMockClient creates a new mock instance
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// AssumeRole mocks base method.
+// AssumeRole mocks base method
 func (m *MockClient) AssumeRole(arg0 *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRole", arg0)
@@ -47,13 +46,13 @@ func (m *MockClient) AssumeRole(arg0 *sts.AssumeRoleInput) (*sts.AssumeRoleOutpu
 	return ret0, ret1
 }
 
-// AssumeRole indicates an expected call of AssumeRole.
+// AssumeRole indicates an expected call of AssumeRole
 func (mr *MockClientMockRecorder) AssumeRole(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRole", reflect.TypeOf((*MockClient)(nil).AssumeRole), arg0)
 }
 
-// GetCallerIdentity mocks base method.
+// GetCallerIdentity mocks base method
 func (m *MockClient) GetCallerIdentity(arg0 *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCallerIdentity", arg0)
@@ -62,13 +61,13 @@ func (m *MockClient) GetCallerIdentity(arg0 *sts.GetCallerIdentityInput) (*sts.G
 	return ret0, ret1
 }
 
-// GetCallerIdentity indicates an expected call of GetCallerIdentity.
+// GetCallerIdentity indicates an expected call of GetCallerIdentity
 func (mr *MockClientMockRecorder) GetCallerIdentity(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCallerIdentity", reflect.TypeOf((*MockClient)(nil).GetCallerIdentity), arg0)
 }
 
-// GetFederationToken mocks base method.
+// GetFederationToken mocks base method
 func (m *MockClient) GetFederationToken(arg0 *sts.GetFederationTokenInput) (*sts.GetFederationTokenOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFederationToken", arg0)
@@ -77,13 +76,13 @@ func (m *MockClient) GetFederationToken(arg0 *sts.GetFederationTokenInput) (*sts
 	return ret0, ret1
 }
 
-// GetFederationToken indicates an expected call of GetFederationToken.
+// GetFederationToken indicates an expected call of GetFederationToken
 func (mr *MockClientMockRecorder) GetFederationToken(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFederationToken", reflect.TypeOf((*MockClient)(nil).GetFederationToken), arg0)
 }
 
-// ListBuckets mocks base method.
+// ListBuckets mocks base method
 func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBuckets", arg0)
@@ -92,13 +91,13 @@ func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutp
 	return ret0, ret1
 }
 
-// ListBuckets indicates an expected call of ListBuckets.
+// ListBuckets indicates an expected call of ListBuckets
 func (mr *MockClientMockRecorder) ListBuckets(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBuckets", reflect.TypeOf((*MockClient)(nil).ListBuckets), arg0)
 }
 
-// DeleteBucket mocks base method.
+// DeleteBucket mocks base method
 func (m *MockClient) DeleteBucket(arg0 *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteBucket", arg0)
@@ -107,13 +106,13 @@ func (m *MockClient) DeleteBucket(arg0 *s3.DeleteBucketInput) (*s3.DeleteBucketO
 	return ret0, ret1
 }
 
-// DeleteBucket indicates an expected call of DeleteBucket.
+// DeleteBucket indicates an expected call of DeleteBucket
 func (mr *MockClientMockRecorder) DeleteBucket(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockClient)(nil).DeleteBucket), arg0)
 }
 
-// ListObjects mocks base method.
+// ListObjects mocks base method
 func (m *MockClient) ListObjects(arg0 *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListObjects", arg0)
@@ -122,13 +121,13 @@ func (m *MockClient) ListObjects(arg0 *s3.ListObjectsInput) (*s3.ListObjectsOutp
 	return ret0, ret1
 }
 
-// ListObjects indicates an expected call of ListObjects.
+// ListObjects indicates an expected call of ListObjects
 func (mr *MockClientMockRecorder) ListObjects(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockClient)(nil).ListObjects), arg0)
 }
 
-// DeleteObjects mocks base method.
+// DeleteObjects mocks base method
 func (m *MockClient) DeleteObjects(arg0 *s3.DeleteObjectsInput) (*s3.DeleteObjectsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteObjects", arg0)
@@ -137,13 +136,13 @@ func (m *MockClient) DeleteObjects(arg0 *s3.DeleteObjectsInput) (*s3.DeleteObjec
 	return ret0, ret1
 }
 
-// DeleteObjects indicates an expected call of DeleteObjects.
+// DeleteObjects indicates an expected call of DeleteObjects
 func (mr *MockClientMockRecorder) DeleteObjects(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObjects", reflect.TypeOf((*MockClient)(nil).DeleteObjects), arg0)
 }
 
-// CreateAccessKey mocks base method.
+// CreateAccessKey mocks base method
 func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccessKey", arg0)
@@ -152,13 +151,13 @@ func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.Creat
 	return ret0, ret1
 }
 
-// CreateAccessKey indicates an expected call of CreateAccessKey.
+// CreateAccessKey indicates an expected call of CreateAccessKey
 func (mr *MockClientMockRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKey", reflect.TypeOf((*MockClient)(nil).CreateAccessKey), arg0)
 }
 
-// DeleteAccessKey mocks base method.
+// DeleteAccessKey mocks base method
 func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccessKey", arg0)
@@ -167,13 +166,13 @@ func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.Delet
 	return ret0, ret1
 }
 
-// DeleteAccessKey indicates an expected call of DeleteAccessKey.
+// DeleteAccessKey indicates an expected call of DeleteAccessKey
 func (mr *MockClientMockRecorder) DeleteAccessKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKey", reflect.TypeOf((*MockClient)(nil).DeleteAccessKey), arg0)
 }
 
-// ListAccessKeys mocks base method.
+// ListAccessKeys mocks base method
 func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccessKeys", arg0)
@@ -182,13 +181,13 @@ func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAcc
 	return ret0, ret1
 }
 
-// ListAccessKeys indicates an expected call of ListAccessKeys.
+// ListAccessKeys indicates an expected call of ListAccessKeys
 func (mr *MockClientMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockClient)(nil).ListAccessKeys), arg0)
 }
 
-// GetUser mocks base method.
+// GetUser mocks base method
 func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUser", arg0)
@@ -197,13 +196,13 @@ func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error)
 	return ret0, ret1
 }
 
-// GetUser indicates an expected call of GetUser.
+// GetUser indicates an expected call of GetUser
 func (mr *MockClientMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), arg0)
 }
 
-// CreateUser mocks base method.
+// CreateUser mocks base method
 func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUser", arg0)
@@ -212,13 +211,13 @@ func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutpu
 	return ret0, ret1
 }
 
-// CreateUser indicates an expected call of CreateUser.
+// CreateUser indicates an expected call of CreateUser
 func (mr *MockClientMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockClient)(nil).CreateUser), arg0)
 }
 
-// ListUsers mocks base method.
+// ListUsers mocks base method
 func (m *MockClient) ListUsers(arg0 *iam.ListUsersInput) (*iam.ListUsersOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUsers", arg0)
@@ -227,13 +226,13 @@ func (m *MockClient) ListUsers(arg0 *iam.ListUsersInput) (*iam.ListUsersOutput, 
 	return ret0, ret1
 }
 
-// ListUsers indicates an expected call of ListUsers.
+// ListUsers indicates an expected call of ListUsers
 func (mr *MockClientMockRecorder) ListUsers(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsers", reflect.TypeOf((*MockClient)(nil).ListUsers), arg0)
 }
 
-// AttachUserPolicy mocks base method.
+// AttachUserPolicy mocks base method
 func (m *MockClient) AttachUserPolicy(arg0 *iam.AttachUserPolicyInput) (*iam.AttachUserPolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachUserPolicy", arg0)
@@ -242,13 +241,13 @@ func (m *MockClient) AttachUserPolicy(arg0 *iam.AttachUserPolicyInput) (*iam.Att
 	return ret0, ret1
 }
 
-// AttachUserPolicy indicates an expected call of AttachUserPolicy.
+// AttachUserPolicy indicates an expected call of AttachUserPolicy
 func (mr *MockClientMockRecorder) AttachUserPolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachUserPolicy", reflect.TypeOf((*MockClient)(nil).AttachUserPolicy), arg0)
 }
 
-// CreatePolicy mocks base method.
+// CreatePolicy mocks base method
 func (m *MockClient) CreatePolicy(arg0 *iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePolicy", arg0)
@@ -257,13 +256,13 @@ func (m *MockClient) CreatePolicy(arg0 *iam.CreatePolicyInput) (*iam.CreatePolic
 	return ret0, ret1
 }
 
-// CreatePolicy indicates an expected call of CreatePolicy.
+// CreatePolicy indicates an expected call of CreatePolicy
 func (mr *MockClientMockRecorder) CreatePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockClient)(nil).CreatePolicy), arg0)
 }
 
-// DeletePolicy mocks base method.
+// DeletePolicy mocks base method
 func (m *MockClient) DeletePolicy(arg0 *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePolicy", arg0)
@@ -272,13 +271,13 @@ func (m *MockClient) DeletePolicy(arg0 *iam.DeletePolicyInput) (*iam.DeletePolic
 	return ret0, ret1
 }
 
-// DeletePolicy indicates an expected call of DeletePolicy.
+// DeletePolicy indicates an expected call of DeletePolicy
 func (mr *MockClientMockRecorder) DeletePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicy", reflect.TypeOf((*MockClient)(nil).DeletePolicy), arg0)
 }
 
-// AttachRolePolicy mocks base method.
+// AttachRolePolicy mocks base method
 func (m *MockClient) AttachRolePolicy(arg0 *iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachRolePolicy", arg0)
@@ -287,13 +286,13 @@ func (m *MockClient) AttachRolePolicy(arg0 *iam.AttachRolePolicyInput) (*iam.Att
 	return ret0, ret1
 }
 
-// AttachRolePolicy indicates an expected call of AttachRolePolicy.
+// AttachRolePolicy indicates an expected call of AttachRolePolicy
 func (mr *MockClientMockRecorder) AttachRolePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachRolePolicy", reflect.TypeOf((*MockClient)(nil).AttachRolePolicy), arg0)
 }
 
-// DetachRolePolicy mocks base method.
+// DetachRolePolicy mocks base method
 func (m *MockClient) DetachRolePolicy(arg0 *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachRolePolicy", arg0)
@@ -302,13 +301,13 @@ func (m *MockClient) DetachRolePolicy(arg0 *iam.DetachRolePolicyInput) (*iam.Det
 	return ret0, ret1
 }
 
-// DetachRolePolicy indicates an expected call of DetachRolePolicy.
+// DetachRolePolicy indicates an expected call of DetachRolePolicy
 func (mr *MockClientMockRecorder) DetachRolePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachRolePolicy", reflect.TypeOf((*MockClient)(nil).DetachRolePolicy), arg0)
 }
 
-// ListAttachedRolePolicies mocks base method.
+// ListAttachedRolePolicies mocks base method
 func (m *MockClient) ListAttachedRolePolicies(arg0 *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedRolePolicies", arg0)
@@ -317,13 +316,13 @@ func (m *MockClient) ListAttachedRolePolicies(arg0 *iam.ListAttachedRolePolicies
 	return ret0, ret1
 }
 
-// ListAttachedRolePolicies indicates an expected call of ListAttachedRolePolicies.
+// ListAttachedRolePolicies indicates an expected call of ListAttachedRolePolicies
 func (mr *MockClientMockRecorder) ListAttachedRolePolicies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePolicies", reflect.TypeOf((*MockClient)(nil).ListAttachedRolePolicies), arg0)
 }
 
-// ListAccountsForParent mocks base method.
+// ListAccountsForParent mocks base method
 func (m *MockClient) ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountsForParent", input)
@@ -332,13 +331,13 @@ func (m *MockClient) ListAccountsForParent(input *organizations.ListAccountsForP
 	return ret0, ret1
 }
 
-// ListAccountsForParent indicates an expected call of ListAccountsForParent.
+// ListAccountsForParent indicates an expected call of ListAccountsForParent
 func (mr *MockClientMockRecorder) ListAccountsForParent(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountsForParent", reflect.TypeOf((*MockClient)(nil).ListAccountsForParent), input)
 }
 
-// ListOrganizationalUnitsForParent mocks base method.
+// ListOrganizationalUnitsForParent mocks base method
 func (m *MockClient) ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListOrganizationalUnitsForParent", input)
@@ -347,13 +346,13 @@ func (m *MockClient) ListOrganizationalUnitsForParent(input *organizations.ListO
 	return ret0, ret1
 }
 
-// ListOrganizationalUnitsForParent indicates an expected call of ListOrganizationalUnitsForParent.
+// ListOrganizationalUnitsForParent indicates an expected call of ListOrganizationalUnitsForParent
 func (mr *MockClientMockRecorder) ListOrganizationalUnitsForParent(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationalUnitsForParent", reflect.TypeOf((*MockClient)(nil).ListOrganizationalUnitsForParent), input)
 }
 
-// DescribeOrganizationalUnit mocks base method.
+// DescribeOrganizationalUnit mocks base method
 func (m *MockClient) DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeOrganizationalUnit", input)
@@ -362,13 +361,13 @@ func (m *MockClient) DescribeOrganizationalUnit(input *organizations.DescribeOrg
 	return ret0, ret1
 }
 
-// DescribeOrganizationalUnit indicates an expected call of DescribeOrganizationalUnit.
+// DescribeOrganizationalUnit indicates an expected call of DescribeOrganizationalUnit
 func (mr *MockClientMockRecorder) DescribeOrganizationalUnit(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeOrganizationalUnit", reflect.TypeOf((*MockClient)(nil).DescribeOrganizationalUnit), input)
 }
 
-// GetCostAndUsage mocks base method.
+// GetCostAndUsage mocks base method
 func (m *MockClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCostAndUsage", input)
@@ -377,13 +376,13 @@ func (m *MockClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (
 	return ret0, ret1
 }
 
-// GetCostAndUsage indicates an expected call of GetCostAndUsage.
+// GetCostAndUsage indicates an expected call of GetCostAndUsage
 func (mr *MockClientMockRecorder) GetCostAndUsage(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCostAndUsage", reflect.TypeOf((*MockClient)(nil).GetCostAndUsage), input)
 }
 
-// CreateCostCategoryDefinition mocks base method.
+// CreateCostCategoryDefinition mocks base method
 func (m *MockClient) CreateCostCategoryDefinition(input *costexplorer.CreateCostCategoryDefinitionInput) (*costexplorer.CreateCostCategoryDefinitionOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCostCategoryDefinition", input)
@@ -392,13 +391,13 @@ func (m *MockClient) CreateCostCategoryDefinition(input *costexplorer.CreateCost
 	return ret0, ret1
 }
 
-// CreateCostCategoryDefinition indicates an expected call of CreateCostCategoryDefinition.
+// CreateCostCategoryDefinition indicates an expected call of CreateCostCategoryDefinition
 func (mr *MockClientMockRecorder) CreateCostCategoryDefinition(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCostCategoryDefinition", reflect.TypeOf((*MockClient)(nil).CreateCostCategoryDefinition), input)
 }
 
-// ListCostCategoryDefinitions mocks base method.
+// ListCostCategoryDefinitions mocks base method
 func (m *MockClient) ListCostCategoryDefinitions(input *costexplorer.ListCostCategoryDefinitionsInput) (*costexplorer.ListCostCategoryDefinitionsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCostCategoryDefinitions", input)
@@ -407,7 +406,7 @@ func (m *MockClient) ListCostCategoryDefinitions(input *costexplorer.ListCostCat
 	return ret0, ret1
 }
 
-// ListCostCategoryDefinitions indicates an expected call of ListCostCategoryDefinitions.
+// ListCostCategoryDefinitions indicates an expected call of ListCostCategoryDefinitions
 func (mr *MockClientMockRecorder) ListCostCategoryDefinitions(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCostCategoryDefinitions", reflect.TypeOf((*MockClient)(nil).ListCostCategoryDefinitions), input)


### PR DESCRIPTION
Fixing a bunch of the boilerplate Makefile stuff to be less complex. This also fixes compilation on darwin, because go is smart enough to always use the current GOOS/GOARCH, so we don't need to hard code this to linux.