### PR TITLE
OSD4804: Add ServiceQuotas command routing with aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bin/
 
 # IDE
 .idea
+.vscode
 
 # MacOS
 .DS_Store

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/osd-utils-cli/cmd/account/get"
 	"github.com/openshift/osd-utils-cli/cmd/account/list"
+	"github.com/openshift/osd-utils-cli/cmd/account/servicequotas"
 )
 
 // NewCmdAccount implements the base account command
@@ -20,6 +21,7 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 
 	accountCmd.AddCommand(get.NewCmdGet(streams, flags))
 	accountCmd.AddCommand(list.NewCmdList(streams, flags))
+	accountCmd.AddCommand(servicequotas.NewCmdServiceQuotas(streams, flags))
 	accountCmd.AddCommand(newCmdReset(streams, flags))
 	accountCmd.AddCommand(newCmdSet(streams, flags))
 	accountCmd.AddCommand(newCmdConsole(streams, flags))

--- a/cmd/account/servicequotas/cmd.go
+++ b/cmd/account/servicequotas/cmd.go
@@ -1,0 +1,26 @@
+package servicequotas
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// NewCmdServiceQuotas implements commands related to AWS service-quotas
+func NewCmdServiceQuotas(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	baseCmd := &cobra.Command{
+		Use:               "servicequotas",
+		Short:             "Interact with AWS service-quotas",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run:               help,
+		Aliases:           []string{"service-quotas", "service-quota"},
+	}
+
+	baseCmd.AddCommand(newCmdDescribe(streams, flags))
+
+	return baseCmd
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	cmd.Help()
+}

--- a/cmd/account/servicequotas/describe.go
+++ b/cmd/account/servicequotas/describe.go
@@ -1,0 +1,127 @@
+package servicequotas
+
+import (
+	"errors"
+	"fmt"
+
+	//"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	k8spkg "github.com/openshift/osd-utils-cli/pkg/k8s"
+	awsprovider "github.com/openshift/osd-utils-cli/pkg/provider/aws"
+)
+
+// newCmdDescribe implements servicequotas describe
+func newCmdDescribe(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newDescribeOptions(streams, flags)
+	describeCmd := &cobra.Command{
+		Use:               "describe",
+		Short:             "Describe AWS service-quotas",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	ops.k8sclusterresourcefactory.AttachCobraCliFlags(describeCmd)
+
+	describeCmd.Flags().StringVarP(&ops.queryServiceCode, "service-code", "", "ec2", "Query for ServiceCode (default: ec2)")
+	describeCmd.Flags().StringVarP(&ops.queryQuotaCode, "quota-code", "q", "", "Query for QuotaCode")
+
+	describeCmd.Flags().BoolVarP(&ops.verbose, "verbose", "v", false, "Verbose output")
+
+	return describeCmd
+}
+
+// describeOptions defines the struct for running list account command
+type describeOptions struct {
+	k8sclusterresourcefactory k8spkg.ClusterResourceFactoryOptions
+
+	queryServiceCode string
+	queryQuotaCode   string
+
+	verbose bool
+
+	genericclioptions.IOStreams
+}
+
+func newDescribeOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *describeOptions {
+	return &describeOptions{
+		k8sclusterresourcefactory: k8spkg.ClusterResourceFactoryOptions{
+			Flags: flags,
+		},
+		IOStreams: streams,
+	}
+}
+
+func (o *describeOptions) complete(cmd *cobra.Command) error {
+	k8svalid, err := o.k8sclusterresourcefactory.ValidateIdentifiers()
+	if !k8svalid {
+		if err != nil {
+			return err
+		}
+	}
+
+	awsvalid, err := o.k8sclusterresourcefactory.Awscloudfactory.ValidateIdentifiers()
+	if !awsvalid {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *describeOptions) run() error {
+	awsClient, err := o.k8sclusterresourcefactory.GetCloudProvider(o.verbose)
+	if err != nil {
+		return err
+	}
+
+	var foundServiceQuotas []*servicequotas.ServiceQuota
+
+	searchQuery := &servicequotas.ListServiceQuotasInput{
+		ServiceCode: &o.queryServiceCode,
+	}
+
+	for {
+		servicequotas, err := awsprovider.Client.ListServiceQuotas(awsClient, searchQuery)
+		if err != nil {
+			return err
+		}
+
+		for _, foundQuota := range servicequotas.Quotas {
+			foundServiceQuotas = append(foundServiceQuotas, foundQuota)
+		}
+
+		// for pagination
+		searchQuery.NextToken = servicequotas.NextToken
+		if servicequotas.NextToken == nil {
+			break
+		}
+	}
+
+	found := false
+	if o.queryQuotaCode == "" {
+		fmt.Println(foundServiceQuotas)
+	} else {
+		for _, quota := range foundServiceQuotas {
+			if *quota.QuotaCode == o.queryQuotaCode {
+				fmt.Println(quota)
+				found = true
+			}
+		}
+	}
+	if !found {
+		return errors.New("Cannot find ServiceQuota (service:" + o.queryServiceCode + " quota:" + o.queryQuotaCode + ")")
+	}
+
+	return nil
+}

--- a/cmd/account/servicequotas/describe.go
+++ b/cmd/account/servicequotas/describe.go
@@ -32,8 +32,8 @@ func newCmdDescribe(streams genericclioptions.IOStreams, flags *genericclioption
 
 	ops.k8sclusterresourcefactory.AttachCobraCliFlags(describeCmd)
 
-	describeCmd.Flags().StringVarP(&ops.queryServiceCode, "service-code", "", "ec2", "Query for ServiceCode (default: ec2)")
-	describeCmd.Flags().StringVarP(&ops.queryQuotaCode, "quota-code", "q", "", "Query for QuotaCode")
+	describeCmd.Flags().StringVarP(&ops.queryServiceCode, "service-code", "", "ec2", "Query for ServiceCode")
+	describeCmd.Flags().StringVarP(&ops.queryQuotaCode, "quota-code", "q", "L-1216C47A", "Query for QuotaCode")
 
 	describeCmd.Flags().BoolVarP(&ops.verbose, "verbose", "v", false, "Verbose output")
 

--- a/docs/command/osdctl_account.md
+++ b/docs/command/osdctl_account.md
@@ -38,6 +38,7 @@ osdctl account [flags]
 * [osdctl account list](osdctl_account_list.md)	 - List resources
 * [osdctl account reset](osdctl_account_reset.md)	 - Reset AWS Account CR
 * [osdctl account rotate-secret](osdctl_account_rotate-secret.md)	 - Rotate IAM credentials secret
+* [osdctl account servicequotas](osdctl_account_servicequotas.md)	 - Interact with AWS service-quotas
 * [osdctl account set](osdctl_account_set.md)	 - Set AWS Account CR status
 * [osdctl account verify-secrets](osdctl_account_verify-secrets.md)	 - Verify AWS Account CR IAM User credentials
 

--- a/docs/command/osdctl_account_servicequotas.md
+++ b/docs/command/osdctl_account_servicequotas.md
@@ -1,0 +1,34 @@
+## osdctl account servicequotas
+
+Interact with AWS service-quotas
+
+### Synopsis
+
+Interact with AWS service-quotas
+
+```
+osdctl account servicequotas [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for servicequotas
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
+```
+
+### SEE ALSO
+
+* [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+* [osdctl account servicequotas describe](osdctl_account_servicequotas_describe.md)	 - Describe AWS service-quotas
+

--- a/docs/command/osdctl_account_servicequotas_describe.md
+++ b/docs/command/osdctl_account_servicequotas_describe.md
@@ -1,13 +1,13 @@
-## osdctl account cli
+## osdctl account servicequotas describe
 
-Generate temporary AWS CLI credentials on demand
+Describe AWS service-quotas
 
 ### Synopsis
 
-Generate temporary AWS CLI credentials on demand
+Describe AWS service-quotas
 
 ```
-osdctl account cli [flags]
+osdctl account servicequotas describe [flags]
 ```
 
 ### Options
@@ -21,8 +21,9 @@ osdctl account cli [flags]
   -r, --aws-region string          specify AWS region (default "us-east-1")
   -C, --cluster-id string          The Internal Cluster ID from Hive to create AWS console URL for
   -d, --duration int               The duration of the console session. Default value is 3600 seconds(1 hour) (default 3600)
-  -h, --help                       help for cli
-  -o, --out string                 Output format [default | json | env] (default "default")
+  -h, --help                       help for describe
+  -q, --quota-code string          Query for QuotaCode
+      --service-code string        Query for ServiceCode (default: ec2) (default "ec2")
   -v, --verbose                    Verbose output
 ```
 
@@ -39,5 +40,5 @@ osdctl account cli [flags]
 
 ### SEE ALSO
 
-* [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+* [osdctl account servicequotas](osdctl_account_servicequotas.md)	 - Interact with AWS service-quotas
 

--- a/docs/command/osdctl_account_servicequotas_describe.md
+++ b/docs/command/osdctl_account_servicequotas_describe.md
@@ -22,8 +22,8 @@ osdctl account servicequotas describe [flags]
   -C, --cluster-id string          The Internal Cluster ID from Hive to create AWS console URL for
   -d, --duration int               The duration of the console session. Default value is 3600 seconds(1 hour) (default 3600)
   -h, --help                       help for describe
-  -q, --quota-code string          Query for QuotaCode
-      --service-code string        Query for ServiceCode (default: ec2) (default "ec2")
+  -q, --quota-code string          Query for QuotaCode (default "L-1216C47A")
+      --service-code string        Query for ServiceCode (default "ec2")
   -v, --verbose                    Verbose output
 ```
 

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -19,6 +19,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/servicequotas"
+	"github.com/aws/aws-sdk-go/service/servicequotas/servicequotasiface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 
@@ -60,6 +62,9 @@ type Client interface {
 	DetachRolePolicy(*iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error)
 	ListAttachedRolePolicies(*iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error)
 
+	// Service Quotas
+	ListServiceQuotas(*servicequotas.ListServiceQuotasInput) (*servicequotas.ListServiceQuotasOutput, error)
+
 	// Organizations
 	ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error)
 	ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
@@ -72,11 +77,12 @@ type Client interface {
 }
 
 type AwsClient struct {
-	iamClient iamiface.IAMAPI
-	stsClient stsiface.STSAPI
-	s3Client  s3iface.S3API
-	orgClient organizationsiface.OrganizationsAPI
-	ceClient  costexploreriface.CostExplorerAPI
+	iamClient           iamiface.IAMAPI
+	stsClient           stsiface.STSAPI
+	s3Client            s3iface.S3API
+	servicequotasClient servicequotasiface.ServiceQuotasAPI
+	orgClient           organizationsiface.OrganizationsAPI
+	ceClient            costexploreriface.CostExplorerAPI
 }
 
 // NewAwsClient creates an AWS client with credentials in the environment
@@ -115,11 +121,12 @@ func NewAwsClient(profile, region, configFile string) (Client, error) {
 	}
 
 	return &AwsClient{
-		iamClient: iam.New(sess),
-		stsClient: sts.New(sess),
-		s3Client:  s3.New(sess),
-		orgClient: organizations.New(sess),
-		ceClient:  costexplorer.New(sess),
+		iamClient:           iam.New(sess),
+		stsClient:           sts.New(sess),
+		s3Client:            s3.New(sess),
+		servicequotasClient: servicequotas.New(sess),
+		orgClient:           organizations.New(sess),
+		ceClient:            costexplorer.New(sess),
 	}, nil
 }
 
@@ -136,11 +143,12 @@ func NewAwsClientWithInput(input *AwsClientInput) (Client, error) {
 	}
 
 	return &AwsClient{
-		iamClient: iam.New(s),
-		stsClient: sts.New(s),
-		s3Client:  s3.New(s),
-		orgClient: organizations.New(s),
-		ceClient:  costexplorer.New(s),
+		iamClient:           iam.New(s),
+		stsClient:           sts.New(s),
+		s3Client:            s3.New(s),
+		servicequotasClient: servicequotas.New(s),
+		orgClient:           organizations.New(s),
+		ceClient:            costexplorer.New(s),
 	}, nil
 }
 
@@ -222,6 +230,10 @@ func (c *AwsClient) ListAttachedRolePolicies(input *iam.ListAttachedRolePolicies
 
 func (c *AwsClient) ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error) {
 	return c.orgClient.ListAccountsForParent(input)
+}
+
+func (c *AwsClient) ListServiceQuotas(input *servicequotas.ListServiceQuotasInput) (*servicequotas.ListServiceQuotasOutput, error) {
+	return c.servicequotasClient.ListServiceQuotas(input)
 }
 
 func (c *AwsClient) ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error) {

--- a/pkg/provider/aws/factory.go
+++ b/pkg/provider/aws/factory.go
@@ -17,6 +17,8 @@ type FactoryOptions struct {
 
 	ConsoleDuration int64
 
+	Credentials *sts.Credentials
+
 	CallerIdentity *sts.GetCallerIdentityOutput
 }
 

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -9,6 +9,7 @@ import (
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	organizations "github.com/aws/aws-sdk-go/service/organizations"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
+	servicequotas "github.com/aws/aws-sdk-go/service/servicequotas"
 	sts "github.com/aws/aws-sdk-go/service/sts"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -320,6 +321,21 @@ func (m *MockClient) ListAttachedRolePolicies(arg0 *iam.ListAttachedRolePolicies
 func (mr *MockClientMockRecorder) ListAttachedRolePolicies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePolicies", reflect.TypeOf((*MockClient)(nil).ListAttachedRolePolicies), arg0)
+}
+
+// ListServiceQuotas mocks base method
+func (m *MockClient) ListServiceQuotas(arg0 *servicequotas.ListServiceQuotasInput) (*servicequotas.ListServiceQuotasOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServiceQuotas", arg0)
+	ret0, _ := ret[0].(*servicequotas.ListServiceQuotasOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServiceQuotas indicates an expected call of ListServiceQuotas
+func (mr *MockClientMockRecorder) ListServiceQuotas(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceQuotas", reflect.TypeOf((*MockClient)(nil).ListServiceQuotas), arg0)
 }
 
 // ListAccountsForParent mocks base method


### PR DESCRIPTION
ServiceQuotas: Add ServiceQuotas command routing with aliases
ServiceQuotas: Query for specific QuotaCode

Account CLI: Have different output formats including default, json, env

Factory: use target credentials from assumed role