### PR TITLE
Add network packet-capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/
 # IDE
 .idea
 .vscode
+*.code-workspace
 
 # MacOS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILDFLAGS ?=
 LDFLAGS = -ldflags="-X '${REPOSITORY}/cmd.GitCommit=${GIT_COMMIT}'"
 unexport GOFLAGS
 
-all: format build test
+all: format mod build test
 
 format: vet fmt mockgen docs
 
@@ -14,7 +14,7 @@ fmt:
 	@gofmt -w -s .
 	@git diff --exit-code .
 
-build: mod
+build:
 	go build ${BUILDFLAGS} ${LDFLAGS} -o ./bin/osdctl main.go
 
 vet:

--- a/cmd/network/cmd.go
+++ b/cmd/network/cmd.go
@@ -1,0 +1,24 @@
+package network
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// NewCmdNetwork implements the base cluster deployment command
+func NewCmdNetwork(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	netCmd := &cobra.Command{
+		Use:               "network",
+		Short:             "network related utilities",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run:               help,
+	}
+
+	netCmd.AddCommand(newCmdPacketCapture(streams, flags))
+	return netCmd
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	cmd.Help()
+}

--- a/cmd/network/packet-capture.go
+++ b/cmd/network/packet-capture.go
@@ -1,0 +1,322 @@
+package network
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/osd-utils-cli/pkg/k8s"
+)
+
+const (
+	packetCaptureImage       = "quay.io/jharrington22/network-toolbox:latest"
+	packetCaptureName        = "packet-capture"
+	packetCaptureNamespace   = "default"
+	outputDir                = "capture-output"
+	nodeLabelKey             = "node-role.kubernetes.io/worker"
+	nodeLabelValue           = ""
+	packetCaptureDurationSec = 60
+)
+
+// newCmdPacketCapture implements the packet-capture command to run a packet capture
+func newCmdPacketCapture(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newPacketCaptureOptions(streams, flags)
+	packetCaptureCmd := &cobra.Command{
+		Use:               "packet-capture",
+		Short:             "Start packet capture",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	packetCaptureCmd.Flags().IntVarP(&ops.duration, "duration", "d", packetCaptureDurationSec, "Duration (in seconds) of packet capture")
+	packetCaptureCmd.Flags().StringVarP(&ops.name, "name", "", packetCaptureName, "Name of Daemonset")
+	packetCaptureCmd.Flags().StringVarP(&ops.namespace, "namespace", "n", packetCaptureNamespace, "Namespace to deploy Daemonset")
+	packetCaptureCmd.Flags().StringVarP(&ops.nodeLabelKey, "node-label-key", "", nodeLabelKey, "Node label key")
+	packetCaptureCmd.Flags().StringVarP(&ops.nodeLabelValue, "node-label-value", "", nodeLabelValue, "Node label value")
+
+	return packetCaptureCmd
+}
+
+// packetCaptureOptions defines the struct for running packet-capture command
+type packetCaptureOptions struct {
+	name           string
+	namespace      string
+	nodeLabelKey   string
+	nodeLabelValue string
+	duration       int
+
+	flags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newPacketCaptureOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *packetCaptureOptions {
+	return &packetCaptureOptions{
+		flags:     flags,
+		IOStreams: streams,
+	}
+}
+
+func (o *packetCaptureOptions) complete(cmd *cobra.Command, _ []string) error {
+	var err error
+	o.kubeCli, err = k8s.NewClient(o.flags)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *packetCaptureOptions) run() error {
+	log.Println("Ensuring Packet Capture Daemonset")
+	ds, err := ensurePacketCaptureDaemonSet(o)
+	if err != nil {
+		log.Fatalf("Error ensuring packet capture daemonset %v", err)
+		return err
+	}
+	log.Println("Waiting For Packet Capture Daemonset")
+	err = waitForPacketCaptureDaemonset(o, ds)
+	if err != nil {
+		log.Fatalf("Error Waiting for daemonset %v", err)
+		return err
+	}
+	log.Println("Copying Files From Packet Capture Pods")
+	err = copyFilesFromPacketCapturePods(o)
+	if err != nil {
+		log.Fatalf("Error copying files %v", err)
+		return err
+	}
+	log.Println("Deleting Packet Capture Daemonset")
+	err = deletePacketCaptureDaemonSet(o, ds)
+	if err != nil {
+		log.Fatalf("Error deleting packet capture daemonset %v", err)
+		return err
+	}
+	return nil
+}
+
+// ensurePacketCaptureDaemonSet ensures the daemonset exists
+func ensurePacketCaptureDaemonSet(o *packetCaptureOptions) (*appsv1.DaemonSet, error) {
+	key := types.NamespacedName{Name: o.name, Namespace: o.namespace}
+	desired := desiredPacketCaptureDaemonSet(o, key)
+	haveDs, current, err := currentPacketCaptureDaemonSet(o, key)
+	if err != nil {
+		log.Fatalf("Error getting current daemonset %v", err)
+		return nil, err
+	}
+
+	if haveDs {
+		log.Println("Already have packet-capture daemonset")
+		return current, nil
+	}
+
+	err = createPacketCaptureDaemonSet(o, desired)
+	if err != nil {
+		log.Fatalf("Error creating packet capture daemonset %v", err)
+		return nil, err
+	}
+
+	log.Println("Successfully ensured packet capture daemonset")
+	return desired, nil
+}
+
+// currentPacketCaptureDaemonSet returns the current daemonset
+func currentPacketCaptureDaemonSet(o *packetCaptureOptions, key types.NamespacedName) (bool, *appsv1.DaemonSet, error) {
+	ds := &appsv1.DaemonSet{}
+
+	if err := o.kubeCli.Get(context.TODO(), key, ds); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil, nil
+		}
+		return false, nil, err
+	}
+	return true, ds, nil
+}
+
+// createPacketCaptureDaemonSet creates the given daemonset resource
+func createPacketCaptureDaemonSet(o *packetCaptureOptions, ds *appsv1.DaemonSet) error {
+	if err := o.kubeCli.Create(context.TODO(), ds); err != nil {
+		return fmt.Errorf("failed to create daemonset %s/%s: %v", ds.Namespace, ds.Name, err)
+	}
+	return nil
+}
+
+// deletePacketCaptureDaemonSet creates the given daemonset resource
+func deletePacketCaptureDaemonSet(o *packetCaptureOptions, ds *appsv1.DaemonSet) error {
+	if err := o.kubeCli.Delete(context.TODO(), ds); err != nil {
+		return fmt.Errorf("failed to delete daemonset %s/%s: %v", ds.Namespace, ds.Name, err)
+	}
+	return nil
+}
+
+// desiredPacketCaptureDaemonSet returns the desired daemonset read in from manifests
+func desiredPacketCaptureDaemonSet(o *packetCaptureOptions, key types.NamespacedName) *appsv1.DaemonSet {
+	ds := &appsv1.DaemonSet{}
+	t := true
+	ls := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app": key.Name,
+		},
+	}
+	ds.Name = key.Name
+	ds.Namespace = key.Namespace
+
+	ds.Spec.Selector = ls
+	ds.Spec.Template.Spec.NodeSelector = map[string]string{
+		o.nodeLabelKey: o.nodeLabelValue,
+	}
+	ds.Spec.Template.Labels = ls.MatchLabels
+	ds.Spec.Template.Spec.Tolerations = []corev1.Toleration{
+		{
+			Effect:   "NoSchedule",
+			Key:      o.nodeLabelKey,
+			Operator: "Exists",
+		},
+	}
+	ds.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "capture-output",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	ds.Spec.Template.Spec.HostNetwork = true
+	ds.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Name:            "init-capture",
+			Image:           packetCaptureImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/bin/bash", "-c", "tcpdump -G " + strconv.Itoa(o.duration) + " -W 1 -w /tmp/capture-output/capture.pcap -i vxlan_sys_4789 -nn -s0; sync"},
+			SecurityContext: &corev1.SecurityContext{Privileged: &t},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "capture-output",
+					MountPath: "/tmp/capture-output",
+					ReadOnly:  false,
+				},
+			},
+		},
+	}
+	ds.Spec.Template.Spec.Containers = []corev1.Container{
+		{
+			Name:            "copy",
+			Image:           packetCaptureImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"},
+			SecurityContext: &corev1.SecurityContext{Privileged: &t},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "capture-output",
+					MountPath: "/tmp/capture-output",
+					ReadOnly:  false,
+				},
+			},
+		},
+	}
+
+	return ds
+}
+
+func copyFilesFromPod(o *packetCaptureOptions, pod *corev1.Pod) error {
+	os.MkdirAll(outputDir, 0755)
+	cmd := exec.Command("oc", "cp", pod.Namespace+"/"+pod.Name+":/tmp/capture-output/capture.pcap", outputDir+"/"+pod.Name+".pcap")
+	var stdBuffer bytes.Buffer
+	mw := io.MultiWriter(os.Stdout, &stdBuffer)
+
+	cmd.Stdout = mw
+	cmd.Stderr = mw
+
+	err := cmd.Run()
+
+	if err != nil {
+		log.Println(stdBuffer.String())
+	}
+
+	return err
+}
+
+func waitForPacketCaptureDaemonset(o *packetCaptureOptions, ds *appsv1.DaemonSet) error {
+	pollErr := wait.PollImmediate(10*time.Second, time.Duration(600)*time.Second, func() (bool, error) {
+		var err error
+		tmp := &appsv1.DaemonSet{}
+		key := types.NamespacedName{Name: ds.Name, Namespace: ds.Namespace}
+		if err = o.kubeCli.Get(context.TODO(), key, tmp); err == nil {
+			ready := (tmp.Status.NumberReady > 0 &&
+				tmp.Status.NumberAvailable == tmp.Status.NumberReady &&
+				tmp.Status.NumberReady == tmp.Status.DesiredNumberScheduled)
+			return ready, nil
+		}
+		return false, err
+	})
+	return pollErr
+}
+
+func waitForPacketCaptureContainerRunning(o *packetCaptureOptions, pod *corev1.Pod) error {
+	pollErr := wait.PollImmediate(10*time.Second, time.Duration(600)*time.Second, func() (bool, error) {
+		var err error
+		tmp := &corev1.Pod{}
+		key := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+		if err = o.kubeCli.Get(context.TODO(), key, tmp); err == nil {
+			if len(tmp.Status.ContainerStatuses) == 0 {
+				return false, nil
+			}
+			state := tmp.Status.ContainerStatuses[0].State
+			running := state.Running != nil
+			return running, nil
+		}
+		return false, err
+	})
+	return pollErr
+}
+
+func copyFilesFromPacketCapturePods(o *packetCaptureOptions) error {
+	var pods corev1.PodList
+
+	if err := o.kubeCli.List(context.TODO(), &pods, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"app": o.name}),
+		Namespace:     o.namespace,
+	}); err != nil {
+		return err
+	}
+	for _, pod := range pods.Items {
+		if len(pod.Status.ContainerStatuses) == 0 {
+			continue
+		}
+		err := waitForPacketCaptureContainerRunning(o, &pod)
+		if err != nil {
+			log.Fatalf("Error waiting for pods %v", err)
+			return err
+		}
+		log.Printf("Copying files from %s\n", pod.Name)
+		err = copyFilesFromPod(o, &pod)
+		if err != nil {
+			log.Fatalf("error copying files %v", err)
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/network/packet-capture.go
+++ b/cmd/network/packet-capture.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	packetCaptureImage       = "quay.io/jharrington22/network-toolbox:latest"
+	packetCaptureImage       = "quay.io/openshift-sre/network-toolbox:latest"
 	packetCaptureName        = "sre-packet-capture"
 	packetCaptureNamespace   = "default"
 	outputDir                = "capture-output"

--- a/cmd/network/packet-capture.go
+++ b/cmd/network/packet-capture.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	packetCaptureImage       = "quay.io/jharrington22/network-toolbox:latest"
-	packetCaptureName        = "packet-capture"
+	packetCaptureName        = "sre-packet-capture"
 	packetCaptureNamespace   = "default"
 	outputDir                = "capture-output"
 	nodeLabelKey             = "node-role.kubernetes.io/worker"

--- a/cmd/network/packet-capture_test.go
+++ b/cmd/network/packet-capture_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-func TestListCmdComplete(t *testing.T) {
+func TestPacketCaptureCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {

--- a/cmd/network/packet-capture_test.go
+++ b/cmd/network/packet-capture_test.go
@@ -1,0 +1,38 @@
+package network
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestListCmdComplete(t *testing.T) {
+	g := NewGomegaWithT(t)
+	kubeFlags := genericclioptions.NewConfigFlags(false)
+	testCases := []struct {
+		title       string
+		option      *packetCaptureOptions
+		errExpected bool
+	}{
+		{
+			title: "succeed",
+			option: &packetCaptureOptions{
+				flags: kubeFlags,
+			},
+			errExpected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			err := tc.option.complete(nil, nil)
+			if tc.errExpected {
+				g.Expect(err).Should(HaveOccurred())
+			} else {
+				g.Expect(err).ShouldNot(HaveOccurred())
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/osd-utils-cli/cmd/clusterdeployment"
 	"github.com/openshift/osd-utils-cli/cmd/cost"
 	"github.com/openshift/osd-utils-cli/cmd/federatedrole"
+	"github.com/openshift/osd-utils-cli/cmd/network"
 )
 
 // GitCommit is the short git commit hash from the environment
@@ -31,7 +32,7 @@ func init() {
 	NewCmdRoot(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 }
 
-// rootCmd represents the base command when called without any subcommands
+// NewCmdRoot represents the base command when called without any subcommands
 func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:               "osdctl",
@@ -60,6 +61,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeFlags))
 	rootCmd.AddCommand(clusterdeployment.NewCmdClusterDeployment(streams, kubeFlags))
 	rootCmd.AddCommand(federatedrole.NewCmdFederatedRole(streams, kubeFlags))
+	rootCmd.AddCommand(network.NewCmdNetwork(streams, kubeFlags))
 	rootCmd.AddCommand(newCmdMetrics(streams, kubeFlags))
 
 	// add docs command

--- a/docs/command/osdctl_network.md
+++ b/docs/command/osdctl_network.md
@@ -1,0 +1,34 @@
+## osdctl network
+
+network related utilities
+
+### Synopsis
+
+network related utilities
+
+```
+osdctl network [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for network
+```
+
+### Options inherited from parent commands
+
+```
+      --cluster string             The name of the kubeconfig cluster to use
+      --context string             The name of the kubeconfig context to use
+      --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
+      --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string              The address and port of the Kubernetes API server
+```
+
+### SEE ALSO
+
+* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl network packet-capture](osdctl_network_packet-capture.md)	 - Start packet capture
+

--- a/docs/command/osdctl_network_packet-capture.md
+++ b/docs/command/osdctl_network_packet-capture.md
@@ -1,21 +1,31 @@
-## osdctl
+## osdctl network packet-capture
 
-OSD CLI
+Start packet capture
 
 ### Synopsis
 
-CLI tool to provide OSD related utilities
+Start packet capture
 
 ```
-osdctl [flags]
+osdctl network packet-capture [flags]
 ```
 
 ### Options
 
 ```
+  -d, --duration int              Duration (in seconds) of packet capture (default 60)
+  -h, --help                      help for packet-capture
+      --name string               Name of Daemonset (default "packet-capture")
+  -n, --namespace string          Namespace to deploy Daemonset (default "default")
+      --node-label-key string     Node label key (default "node-role.kubernetes.io/worker")
+      --node-label-value string   Node label value
+```
+
+### Options inherited from parent commands
+
+```
       --cluster string             The name of the kubeconfig cluster to use
       --context string             The name of the kubeconfig context to use
-  -h, --help                       help for osdctl
       --insecure-skip-tls-verify   If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string          Path to the kubeconfig file to use for CLI requests.
       --request-timeout string     The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
@@ -24,12 +34,5 @@ osdctl [flags]
 
 ### SEE ALSO
 
-* [osdctl account](osdctl_account.md)	 - AWS Account related utilities
-* [osdctl clusterdeployment](osdctl_clusterdeployment.md)	 - cluster deployment related utilities
-* [osdctl completion](osdctl_completion.md)	 - Output shell completion code for the specified shell (bash or zsh)
-* [osdctl cost](osdctl_cost.md)	 - Cost Management related utilities
-* [osdctl federatedrole](osdctl_federatedrole.md)	 - federated role related commands
-* [osdctl metrics](osdctl_metrics.md)	 - Display metrics of aws-account-operator
 * [osdctl network](osdctl_network.md)	 - network related utilities
-* [osdctl options](osdctl_options.md)	 - Print the list of flags inherited by all commands
 

--- a/docs/command/osdctl_network_packet-capture.md
+++ b/docs/command/osdctl_network_packet-capture.md
@@ -15,7 +15,7 @@ osdctl network packet-capture [flags]
 ```
   -d, --duration int              Duration (in seconds) of packet capture (default 60)
   -h, --help                      help for packet-capture
-      --name string               Name of Daemonset (default "packet-capture")
+      --name string               Name of Daemonset (default "sre-packet-capture")
   -n, --namespace string          Namespace to deploy Daemonset (default "default")
       --node-label-key string     Node label key (default "node-role.kubernetes.io/worker")
       --node-label-value string   Node label value


### PR DESCRIPTION
This adds a new domain (`network`) and action: (`packet-capture`) which runs a privileged tcpdump on nodes for a given duration (60s). After completion, will copy the .pcap files to the local directory (./capture-output/).

Options:
```
$ osdctl help network packet-capture
Start packet capture

Options:
  -d, --duration=60: Duration (in seconds) of packet capture
      --name='packet-capture': Name of Daemonset
  -n, --namespace='default': Namespace to deploy Daemonset
      --node-label-key='node-role.kubernetes.io/worker': Node label key
      --node-label-value='': Node label value

Usage:
  osdctl network packet-capture [flags] [options]

Use "osdctl options" for a list of global command-line options (applies to all commands).
```

Example run:
```
dustinrow@drow-mac:~/src/osd-utils-cli$ ./bin/osdctl network packet-capture
2020/12/09 20:53:51 Ensuring Packet Capture Daemonset
2020/12/09 20:53:51 Successfully ensured packet capture daemonset
2020/12/09 20:53:51 Waiting For Packet Capture Daemonset
2020/12/09 20:55:01 Copying Files From Packet Capture Pods
2020/12/09 20:55:01 Copying files from packet-capture-28qck
tar: Removing leading `/' from member names
2020/12/09 20:55:02 Copying files from packet-capture-8rsp7
tar: Removing leading `/' from member names
2020/12/09 20:55:03 Copying files from packet-capture-cxlnj
tar: Removing leading `/' from member names
2020/12/09 20:55:05 Copying files from packet-capture-jsbn7
tar: Removing leading `/' from member names
2020/12/09 20:55:07 Copying files from packet-capture-n5x7q
tar: Removing leading `/' from member names
2020/12/09 20:55:08 Copying files from packet-capture-vhcgj
tar: Removing leading `/' from member names
2020/12/09 20:55:09 Deleting Packet Capture Daemonset
dustinrow@drow-mac:~/src/osd-utils-cli$ ls -al ./capture-output/
total 5968
drwxr-xr-x  8 dustinrow staff     256 Dec  9 20:55 .
drwxr-xr-x 19 dustinrow staff     608 Dec  9 20:55 ..
-rw-r--r--  1 dustinrow staff  22972 Dec 14 13:56 ip-10-0-149-114.us-west-2.compute.internal-20201214T215510.pcap
-rw-r--r--  1 dustinrow staff  23310 Dec 14 13:56 ip-10-0-166-239.us-west-2.compute.internal-20201214T215510.pcap
-rw-r--r--  1 dustinrow staff  73776 Dec 14 13:56 ip-10-0-180-197.us-west-2.compute.internal-20201214T215510.pcap
-rw-r--r--  1 dustinrow staff  93627 Dec 14 13:54 ip-10-0-201-138.us-west-2.compute.internal-20201214T215359.pcap
-rw-r--r--  1 dustinrow staff  84173 Dec 14 13:56 ip-10-0-201-138.us-west-2.compute.internal-20201214T215510.pcap
-rw-r--r--  1 dustinrow staff  62683 Dec 14 13:56 ip-10-0-211-217.us-west-2.compute.internal-20201214T215510.pcap
-rw-r--r--  1 dustinrow staff 576531 Dec 14 13:54 ip-10-0-228-43.us-west-2.compute.internal-20201214T215359.pcap
-rw-r--r--  1 dustinrow staff 648548 Dec 14 13:56 ip-10-0-228-43.us-west-2.compute.internal-20201214T215510.pcap
```